### PR TITLE
Remove zdbMatch option (GOkbIT-138)

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -925,7 +925,6 @@
       "updateNow": "Jetzt Importieren",
       "lastRun": "Letzter Durchlauf",
       "ezbMatch": "EZB-Abgleich",
-      "zdbMatch": "ZDB-Abgleich",
       "enableUpdate": "Aktiviert",
       "url": "URL",
       "frequency": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -924,7 +924,6 @@
       "updateNow": "Import Now",
       "lastRun": "Last Run",
       "ezbMatch": "Match EZB",
-      "zdbMatch": "Match ZDB",
       "enableUpdate": "Activated",
       "url": "URL",
       "frequency": {

--- a/src/shared/components/complex/gokb-source-field/gokb-source-field.vue
+++ b/src/shared/components/complex/gokb-source-field/gokb-source-field.vue
@@ -111,7 +111,6 @@
           url: undefined,
           targetNamespace: undefined,
           ezbMatch: undefined,
-          zdbMatch: undefined,
           automaticUpdates: undefined,
           update: false
         },
@@ -202,7 +201,6 @@
             this.item.name = result.data.name
             this.item.url = result.data.url
             this.item.automaticUpdates = result.data.automaticUpdates
-            this.item.zdbMatch = result.data.zdbMatch
             this.item.ezbMatch = result.data.ezbMatch
           }
         }

--- a/src/views/edit/edit-package-view.vue
+++ b/src/views/edit/edit-package-view.vue
@@ -785,7 +785,6 @@
             update: false,
             url: undefined,
             ezbMatch: false,
-            zdbMatch: false,
             automaticUpdates: false,
             targetNamespace: options.selectedNamespace,
             duration: undefined,


### PR DESCRIPTION
Removed the `zdbMatch` option completely, assuming that the later-on ZDB enrichment is active for each package and shall not be configurable.