### PR TITLE
279 status icon

### DIFF
--- a/src/shared/components/base/gokb-search-field/gokb-search-field.vue
+++ b/src/shared/components/base/gokb-search-field/gokb-search-field.vue
@@ -82,7 +82,7 @@
           <span
             v-if="!!item.status"
           >
-            <v-icon :color= "statusColor(item.status)">
+            <v-icon :color="statusColor(item.status)">
               {{ statusIcon(item.status) }}
             </v-icon>
           </span>
@@ -149,10 +149,11 @@
       </span>
     </template>
     <template #item="{ item }">
+      {{ item[itemText] }}
       <span
         v-if="!!item.status"
       >
-        <v-icon :color= "statusColor(item.status)">
+        <v-icon :color="statusColor(item.status)">
           {{ statusIcon(item.status) }}
         </v-icon>
       </span>

--- a/src/shared/components/base/gokb-search-field/gokb-search-field.vue
+++ b/src/shared/components/base/gokb-search-field/gokb-search-field.vue
@@ -76,15 +76,24 @@
       </span>
     </template>
     <template #item="{ item }">
-      <div :style="{ color: (item.disabled ? '#888888' : 'inherit') }">
-        {{ item[itemText] }}
-        <v-chip
-          v-if="item.disabled && !!item.disabledMessage"
-          color="error"
-        >
-          <span> {{ $t(item.disabledMessage) }} </span>
-        </v-chip>
-      </div>
+      <span>
+        <div :style="{ color: (item.disabled ? '#888888' : 'inherit') }">
+          {{ item[itemText] }}
+          <span>
+            <v-icon :color= "statusColor('{{ item.status }}')"
+              v-if="!!item"
+            >
+              {{ statusIcon(item.status) }}
+            </v-icon>
+          </span>
+          <v-chip
+            v-if="item.disabled && !!item.disabledMessage"
+            color="error"
+          >
+            <span> {{ $t(item.disabledMessage) }} </span>
+          </v-chip>
+        </div>
+      </span>
     </template>
   </v-combobox>
   <v-autocomplete
@@ -303,6 +312,20 @@
         this.items = []
         this.localValue = undefined
         this.$refs.autocomplete.lazyValue = undefined
+      },
+      statusColor (status) {
+        if (status?.name == "Current") return "success"
+        if (status?.name == "Deleted") return "red"
+        if (status?.name == "Expected") return "info"
+        if (status?.name == "Retired") return "amber"
+        return "default"
+      },
+      statusIcon (status) {
+        if (status?.name == "Current") return "mdi-check-circle"
+        if (status?.name == "Deleted") return "mdi-delete"
+        if (status?.name == "Expected") return "mdi-clock"
+        if (status?.name == "Retired") return "mdi-close-circle"
+        return undefined
       }
     }
   }

--- a/src/shared/components/base/gokb-search-field/gokb-search-field.vue
+++ b/src/shared/components/base/gokb-search-field/gokb-search-field.vue
@@ -79,10 +79,10 @@
       <span>
         <div :style="{ color: (item.disabled ? '#888888' : 'inherit') }">
           {{ item[itemText] }}
-          <span>
-            <v-icon :color= "statusColor('{{ item.status }}')"
-              v-if="!!item"
-            >
+          <span
+            v-if="!!item.status"
+          >
+            <v-icon :color= "statusColor(item.status)">
               {{ statusIcon(item.status) }}
             </v-icon>
           </span>
@@ -146,6 +146,15 @@
         >
           {{ data.item[itemText] }}
         </span>
+      </span>
+    </template>
+    <template #item="{ item }">
+      <span
+        v-if="!!item.status"
+      >
+        <v-icon :color= "statusColor(item.status)">
+          {{ statusIcon(item.status) }}
+        </v-icon>
       </span>
     </template>
   </v-autocomplete>


### PR DESCRIPTION
The autocomplete section does not work, yet.

Problem is: the content of the second replaces the content of the first one. So you only see the icons now, but not the text any more.

I had a try combining text and icons in the existing nested template, but this didn't work for me at all - no icons where visible at no time at all.