### PR TITLE
move up snackbars in template to remove refresh interaction

### DIFF
--- a/src/shared/components/complex/gokb-reviews-section/gokb-reviews-section.vue
+++ b/src/shared/components/complex/gokb-reviews-section/gokb-reviews-section.vue
@@ -83,28 +83,28 @@
       >
         {{ bulkCloseLabel }}
       </gokb-button>
-      <span v-if="errorMsg">
-        <v-alert
-          type="error"
-          dismissible
-        >
-          {{ localErrorMessage }}
-        </v-alert>
-      </span>
-      <span v-if="successMessage">
-        <v-alert
-          type="success"
-          dismissible
-        >
-          {{ successMessage }}
-        </v-alert>
-      </span>
     </template>
     <gokb-confirmation-popup
       v-model="confirmationPopUpVisible"
       :message="messageToConfirm"
       @confirmed="executeAction(actionToConfirm, parameterToConfirm)"
     />
+    <span v-if="errorMsg">
+      <v-alert
+        type="error"
+        dismissible
+      >
+        {{ localErrorMessage }}
+      </v-alert>
+    </span>
+    <span v-if="successMessage">
+      <v-alert
+        type="success"
+        dismissible
+      >
+        {{ successMessage }}
+      </v-alert>
+    </span>
     <gokb-table
       ref="rtable"
       :items="reviews"

--- a/src/views/edit/edit-package-view.vue
+++ b/src/views/edit/edit-package-view.vue
@@ -1,649 +1,651 @@
 <template>
-  <gokb-page
-    v-if="accessible && !notFound"
-    :key="version"
-    :title="title"
-    :sub-title="subTitle"
-    @submit="showSubmitPackageConfirm"
-  >
-    <gokb-error-component :value="error" />
+  <div>
     <v-snackbars :objects.sync="eventMessages">
       <template #action="{ close }">
         <v-btn icon @click="close()"><v-icon>mdi-close</v-icon></v-btn>
       </template>
     </v-snackbars>
-    <span v-if="importJob?.result === 'success'">
-      <v-alert
-        type="success"
-        dismissible
-      >
-        {{ importJob.dryRun ? $t('kbart.dryRun.success') : $t('kbart.transmission.success') }}
-        <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(importJob.id)">
-          {{ $t('kbart.transmission.showResults') }}
-        </gokb-button>
-      </v-alert>
-    </span>
-    <span v-if="importJob?.result === 'error'">
-      <v-alert
-        type="error"
-        dismissible
-      >
-        {{ $t('kbart.transmission.error.processing') }}
-        <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(importJob.id)">
-          {{ $t('kbart.transmission.showResults') }}
-        </gokb-button>
-      </v-alert>
-    </span>
-    <span v-if="importJob?.result === 'warn'">
-      <v-alert
-        type="warning"
-        dismissible
-      >
-        {{ $t('kbart.transmission.warn.skipped') }}
-        <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(importJob.id)">
-          {{ $t('kbart.transmission.showResults') }}
-        </gokb-button>
-      </v-alert>
-    </span>
-    <span v-else-if="importJob?.result === 'info'">
-      <v-alert
-        type="info"
-        dismissible
-      >
-        <span>
-          {{ importJob.dryRun ? $t('kbart.dryRun.started') : $t('kbart.transmission.started') }} {{ '(' + importJob.progress + '%)' }}
-          <v-progress-linear
-            v-if="!!importJob.progress"
-            v-model="importJob.progress"
-          />
-          <div v-else>
-            {{ $t('kbart.transmission.preparing') }}
-          </div>
-        </span>
-      </v-alert>
-    </span>
-    <span v-if="matchingJob?.result === 'success'">
-      <v-alert
-        type="success"
-        dismissible
-      >
-        {{ $t('kbart.titleMatch.success') }}
-        <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(matchingJob.id)">
-          {{ $t('kbart.transmission.showResults') }}
-        </gokb-button>
-      </v-alert>
-    </span>
-    <span v-if="matchingJob?.result === 'error'">
-      <v-alert
-        type="error"
-        dismissible
-      >
-        {{ $t(matchingJob.messageCode) }}
-        <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(matchingJob.id)">
-          {{ $t('kbart.transmission.showResults') }}
-        </gokb-button>
-      </v-alert>
-    </span>
-    <span v-else-if="matchingJob?.result === 'info'">
-      <v-alert
-        type="info"
-        dismissible
-      >
-        <span>
-          {{ $t('kbart.titleMatch.started') }} {{ '(' + matchingJob.progress + '%)' }}
-          <v-progress-linear
-            v-if="!!matchingJob.progress"
-            v-model="matchingJob.progress"
-          />
-          <div v-else>
-            {{ $t('kbart.transmission.preparing') }}
-          </div>
-        </span>
-      </v-alert>
-    </span>
-    <gokb-edit-job-popup
-      v-if="editJobPopupVisible"
-      v-model="editJobPopupVisible"
-      :selected="selectedJob"
-    />
-    <v-stepper
-      v-model="step"
-      alt-labels
+    <gokb-page
+      v-if="accessible && !notFound"
+      :key="version"
+      :title="title"
+      :sub-title="subTitle"
+      @submit="showSubmitPackageConfirm"
     >
-      <v-stepper-header>
-        <v-stepper-step
-          editable
-          :step="1"
+      <gokb-error-component :value="error" />
+      <span v-if="importJob?.result === 'success'">
+        <v-alert
+          type="success"
+          dismissible
         >
-          {{ isEdit ? $t('component.package.navigation.step4') : $t('component.package.navigation.step1') }}
-        </v-stepper-step>
-        <v-divider />
-        <v-stepper-step
-          :editable="currentStepValid"
-          :class="{ error: !!step2Error }"
-          :step="2"
+          {{ importJob.dryRun ? $t('kbart.dryRun.success') : $t('kbart.transmission.success') }}
+          <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(importJob.id)">
+            {{ $t('kbart.transmission.showResults') }}
+          </gokb-button>
+        </v-alert>
+      </span>
+      <span v-if="importJob?.result === 'error'">
+        <v-alert
+          type="error"
+          dismissible
         >
-          {{ isEdit ? $t('component.package.navigation.step1') : $t('component.package.navigation.step2') }}
-        </v-stepper-step>
-        <v-divider />
-        <v-stepper-step
-          :editable="currentStepValid"
-          :class="{ error: !!step3Error }"
-          :step="3"
+          {{ $t('kbart.transmission.error.processing') }}
+          <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(importJob.id)">
+            {{ $t('kbart.transmission.showResults') }}
+          </gokb-button>
+        </v-alert>
+      </span>
+      <span v-if="importJob?.result === 'warn'">
+        <v-alert
+          type="warning"
+          dismissible
         >
-          {{ isEdit ? $t('component.package.navigation.step2') : $t('component.package.navigation.step3') }}
-        </v-stepper-step>
-        <v-divider />
-        <v-stepper-step
-          :editable="currentStepValid"
-          :step="4"
+          {{ $t('kbart.transmission.warn.skipped') }}
+          <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(importJob.id)">
+            {{ $t('kbart.transmission.showResults') }}
+          </gokb-button>
+        </v-alert>
+      </span>
+      <span v-else-if="importJob?.result === 'info'">
+        <v-alert
+          type="info"
+          dismissible
         >
-          {{ isEdit ? $t('component.package.navigation.step3') : $t('component.package.navigation.step4') }}
-        </v-stepper-step>
-      </v-stepper-header>
-
-      <v-stepper-items>
-        <v-stepper-content :step="isEdit ? 2 : 1">
-          <gokb-section :no-tool-bar="true">
-            <gokb-name-field
-              v-model="allNames"
-              :disabled="isReadonly"
-              :required="!isReadonly"
-              check-dupes="Package"
-              :item-id="packageItem.id"
+          <span>
+            {{ importJob.dryRun ? $t('kbart.dryRun.started') : $t('kbart.transmission.started') }} {{ '(' + importJob.progress + '%)' }}
+            <v-progress-linear
+              v-if="!!importJob.progress"
+              v-model="importJob.progress"
             />
-            <gokb-url-field
-              v-model="packageItem.descriptionURL"
-              :disabled="isReadonly"
-              :label="$t('component.package.descriptionUrl')"
+            <div v-else>
+              {{ $t('kbart.transmission.preparing') }}
+            </div>
+          </span>
+        </v-alert>
+      </span>
+      <span v-if="matchingJob?.result === 'success'">
+        <v-alert
+          type="success"
+          dismissible
+        >
+          {{ $t('kbart.titleMatch.success') }}
+          <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(matchingJob.id)">
+            {{ $t('kbart.transmission.showResults') }}
+          </gokb-button>
+        </v-alert>
+      </span>
+      <span v-if="matchingJob?.result === 'error'">
+        <v-alert
+          type="error"
+          dismissible
+        >
+          {{ $t(matchingJob.messageCode) }}
+          <gokb-button class="ml-2" style="margin-top:-2px;" :label="$t('kbart.transmission.showResults')" @click="showJobPopup(matchingJob.id)">
+            {{ $t('kbart.transmission.showResults') }}
+          </gokb-button>
+        </v-alert>
+      </span>
+      <span v-else-if="matchingJob?.result === 'info'">
+        <v-alert
+          type="info"
+          dismissible
+        >
+          <span>
+            {{ $t('kbart.titleMatch.started') }} {{ '(' + matchingJob.progress + '%)' }}
+            <v-progress-linear
+              v-if="!!matchingJob.progress"
+              v-model="matchingJob.progress"
             />
-            <gokb-textarea-field
-              ref="descEdit"
-              v-model="packageItem.description"
-              :label="$t('component.package.description')"
-              :disabled="isReadonly"
-            />
-          </gokb-section>
-          <v-row>
-            <v-col
-              cols="12"
-              xl="6"
-            >
-              <gokb-section
-                :sub-title="$t('component.package.provider')"
-                :mark-required="!isReadonly"
-              >
-                <gokb-search-organisation-field
-                  v-model="packageItem.provider"
-                  :items="providerSelection"
-                  :show-link="true"
-                  :readonly="isReadonly"
-                  return-object
-                />
-              </gokb-section>
-            </v-col>
-            <v-col
-              cols="12"
-              xl="6"
-            >
-              <gokb-section
-                :sub-title="$t('component.package.platform')"
-                :mark-required="!isReadonly"
-              >
-                <gokb-search-platform-field
-                  v-model="packageItem.nominalPlatform"
-                  :items="platformSelection"
-                  :readonly="isReadonly"
-                  return-object
-                />
-              </gokb-section>
-            </v-col>
-          </v-row>
-        </v-stepper-content>
-
-        <v-stepper-content :step="isEdit ? 3 : 2">
-          <gokb-section :no-tool-bar="true">
-            <v-row
-              class="pt-4"
-              dense
-            >
-              <v-col>
-                <gokb-state-field
-                  v-model="packageItem.scope"
-                  :init-item="packageItem.scope"
-                  width="100%"
-                  message-path="component.package.scope"
-                  url="refdata/categories/Package.Scope"
-                  :label="$t('component.package.scope.label')"
-                  :readonly="isReadonly"
-                  dense
-                />
-              </v-col>
-              <v-col>
-                <gokb-state-field
-                  v-model="packageItem.contentType"
-                  :init-item="packageItem.contentType"
-                  width="100%"
-                  message-path="component.package.contentType"
-                  url="refdata/categories/Package.ContentType"
-                  :label="$t('component.package.contentType.label')"
-                  :readonly="isReadonly"
-                  dense
-                />
-              </v-col>
-              <v-col>
-                <gokb-state-field
-                  v-if="!!id"
-                  v-model="packageItem.editStatus"
-                  :init-item="packageItem.editStatus"
-                  message-path="component.general.editStatus"
-                  url="refdata/categories/KBComponent.EditStatus"
-                  width="100%"
-                  :label="$t('component.general.editStatus.label')"
-                  :readonly="isReadonly"
-                  dense
-                />
-              </v-col>
-              <v-col>
-                <gokb-state-field
-                  v-if="!!id"
-                  v-model="packageItem.listStatus"
-                  message-path="component.package.listStatus"
-                  url="refdata/categories/Package.ListStatus"
-                  width="100%"
-                  :label="$t('component.package.listStatus.label')"
-                  :readonly="isReadonly"
-                  dense
-                />
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col cols="7">
-                <div>
-                  <label for="validity">{{ $t('component.package.global.label') }}</label>
-                </div>
-                <gokb-radiobutton-group
-                  id="validity"
-                  v-model="packageItem.global"
-                >
-                  <gokb-radiobutton-field
-                    value="Global"
-                    :label="$t('component.package.global.Global.label')"
-                    :readonly="isReadonly"
-                  />
-                  <gokb-radiobutton-field
-                    value="Consortium"
-                    :label="$t('component.package.global.Consortium.label')"
-                    :readonly="isReadonly"
-                  />
-                  <gokb-radiobutton-field
-                    value="Regional"
-                    :label="$t('component.package.global.Regional.label')"
-                    :readonly="isReadonly"
-                  />
-                  <gokb-radiobutton-field
-                    value="Other"
-                    :label="$t('component.package.global.Other.label')"
-                    :readonly="isReadonly"
-                  />
-                  <gokb-radiobutton-field
-                    value="Local"
-                    :label="$t('component.package.global.Local.label')"
-                    :readonly="isReadonly"
-                  />
-                </gokb-radiobutton-group>
-              </v-col>
-              <v-col cols="1">
-                <v-icon
-                  v-if="packageItem.global === 'Consortium' || packageItem.global === 'Regional' || packageItem.global === 'Other' || packageItem.global === 'Local'"
-                  class="mt-6"
-                >
-                  mdi-chevron-triple-right
-                </v-icon>
-              </v-col>
-              <v-col cols="4">
-                <gokb-text-field
-                  v-if="packageItem.global === 'Consortium' || packageItem.global === 'Regional' || packageItem.global === 'Other' || packageItem.global === 'Local'"
-                  v-model="packageItem.globalNote"
-                  :label="$t('component.package.globalNote.label')"
-                  :disabled="isReadonly"
-                />
-              </v-col>
-            </v-row>
-            <v-row>
-              <gokb-checkbox-field
-                v-model="packageItem.consistent"
-                class="ml-3"
-                :label="$t('component.package.consistent')"
-                :readonly="isReadonly"
-              />
-              <gokb-checkbox-field
-                v-model="packageItem.breakable"
-                class="ml-3"
-                :label="$t('component.package.breakable')"
-                :readonly="isReadonly"
-              />
-              <gokb-checkbox-field
-                v-model="packageItem.fixed"
-                class="ml-3"
-                :label="$t('component.package.fixed')"
-                :readonly="isReadonly"
-              />
-            </v-row>
-          </gokb-section>
-          <v-row>
-            <v-col
-              cols="12"
-              xl="6"
-            >
-              <gokb-identifier-section
-                v-model="packageItem.ids"
-                target-type="Package"
-                :disabled="isReadonly"
-                :api-errors="errors?.ids"
-              />
-            </v-col>
-            <v-col
-              cols="12"
-              xl="6"
-            >
-              <gokb-alternate-names-section
-                v-model="allNames.alts"
-                :disabled="isReadonly"
-                :api-errors="errors?.variantNames"
-              />
-            </v-col>
-          </v-row>
-        </v-stepper-content>
-
-        <v-stepper-content :step="isEdit ? 4 : 3">
-          <v-row v-if="kbart && kbart.selectedFile">
-            <v-col>
-              <v-chip
-                class="ml-6"
-                close
-                @click:close="kbart = undefined"
-              >
-                {{ kbart.selectedFile.name }} ({{ kbart.lineCount }} {{ $tc('kbart.row.label', kbart.lineCount) }})
-                <v-icon
-                  v-if="kbart.dryRun"
-                  class="ml-1"
-                  :title="$t('kbart.dryRun.label')"
-                  small
-                >
-                  mdi-content-save-off
-                </v-icon>
-              </v-chip>
-            </v-col>
-          </v-row>
-          <gokb-tipps-section
-            ref="tipps"
-            :pkg="id"
-            :filter-align="isEdit"
-            :platform="packageItem.nominalPlatform"
-            :provider="packageItem.provider"
-            :disabled="isReadonly"
-            :api-errors="errors?.tipps"
-            @kbart="setKbart"
-            @update="updateNewTipps"
-          />
-          <gokb-source-field
-            v-if="loggedIn"
-            ref="source"
-            v-model="sourceItem"
-            :default-title-namespace="providerTitleNamespace"
-            :expanded="false"
-            :api-errors="errors?.source"
-            :readonly="isReadonly"
-            @enable="triggerUpdate"
-          />
-        </v-stepper-content>
-
-        <v-stepper-content :step="isEdit ? 1 : 4">
-          <gokb-section :no-tool-bar="true">
-            <v-row>
-              <v-col>
-                <gokb-name-field
-                  v-model="allNames"
-                  dense
-                  readonly
-                />
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col cols="6">
-                <gokb-state-select-field
-                  v-if="packageItem.status"
-                  v-model="packageItem.status"
-                  dense
-                  :deletable="!isReadonly"
-                  :editable="!isReadonly"
-                  @delete="markDeleted"
-                />
-              </v-col>
-              <v-col cols="6" xl="3">
-                <gokb-uuid-field
-                  v-if="uuid"
-                  label="UUID"
-                  :value="uuid"
-                  path="/package"
-                  dense
-                />
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col>
-                <gokb-text-field
-                  v-model="providerName"
-                  :label="$t('component.package.provider')"
-                  dense
-                  disabled
-                />
-              </v-col>
-              <v-col>
-                <gokb-text-field
-                  v-model="platformName"
-                  :label="$t('component.package.platform')"
-                  dense
-                  disabled
-                />
-              </v-col>
-            </v-row>
-            <v-row v-if="packageItem.description">
-              <v-col>
-                <gokb-textarea-field
-                  ref="descInfo"
-                  v-model="packageItem.description"
-                  :label="$t('component.package.description')"
-                  dense
-                  disabled
-                />
-              </v-col>
-            </v-row>
-            <v-row v-if="id">
-              <v-col cols="3">
-                <gokb-state-field
-                  v-model="overviewStates.contentType"
-                  :init-item="overviewStates.contentType"
-                  message-path="component.package.contentType"
-                  url="refdata/categories/Package.ContentType"
-                  :label="$t('component.package.contentType.label')"
-                  dense
-                  readonly
-                />
-              </v-col>
-              <v-col cols="2">
-                <gokb-number-field
-                  :value="totalNumberOfTitles"
-                  :label="$tc('component.tipp.label', 2)"
-                  dense
-                  disabled
-                />
-              </v-col>
-              <v-col cols="3">
-                <gokb-state-field
-                  v-model="overviewStates.listStatus"
-                  :init-item="overviewStates.listStatus"
-                  message-path="component.package.listStatus"
-                  url="refdata/categories/Package.ListStatus"
-                  :label="$t('component.package.listStatus.label')"
-                  :api-errors="errors?.listStatus"
-                  dense
-                  readonly
-                />
-              </v-col>
-              <v-col>
-                <gokb-text-field
-                  v-if="listVerifiedDate"
-                  v-model="localListVerifiedDate"
-                  :label="$t('component.package.listVerifiedDate.label')"
-                  dense
-                  disabled
-                />
-              </v-col>
-            </v-row>
-            <v-row>
-              <v-col v-if="kbart && kbart.selectedFile">
-                <gokb-text-field
-                  v-model="kbart.selectedFile.name"
-                  :label="kbartLabel"
-                  dense
-                  disabled
-                />
-              </v-col>
-            </v-row>
-          </gokb-section>
-          <gokb-section
-            v-if="maintenance"
-            :sub-title="$tc('component.maintenance.label', 2)"
-          >
-            <gokb-maintenance-cycle-field v-model="maintenanceCycle" />
-            <gokb-date-field
-              v-model="dueTo"
-              label="Fällig am"
-              disabled
-            />
-          </gokb-section>
-          <v-row>
-            <v-col
-              cols="12"
-              xl="5"
-            >
-              <gokb-curatory-group-section
-                v-model="allCuratoryGroups"
-                :disabled="!isAdmin"
-                :filter-align="false"
-                :expandable="false"
-                :sub-title="$tc('component.curatoryGroup.label', 2)"
-              />
-            </v-col>
-            <v-col
-              cols="12"
-              xl="7"
-            >
-              <gokb-reviews-section
-                v-if="id && isContrib"
-                :expandable="false"
-                :review-component="packageItem"
-                :api-errors="errors?.listStatus"
-                @update=reload
-              />
-            </v-col>
-          </v-row>
-          <v-row v-if="id && !isReadonly">
-            <v-col>
-              <gokb-jobs-section
-                :linked-component="id"
-                :hide-default="true"
-                :auto-refresh="false"
-              />
-            </v-col>
-          </v-row>
-        </v-stepper-content>
-      </v-stepper-items>
-    </v-stepper>
-
-    <template #buttons>
-      <gokb-confirmation-popup
-        v-model="showSubmitConfirm"
-        :message="submitConfirmationMessage"
-        @confirmed="submitPackage"
+            <div v-else>
+              {{ $t('kbart.transmission.preparing') }}
+            </div>
+          </span>
+        </v-alert>
+      </span>
+      <gokb-edit-job-popup
+        v-if="editJobPopupVisible"
+        v-model="editJobPopupVisible"
+        :selected="selectedJob"
       />
-      <gokb-button
-        v-if="!isReadonly"
-        @click="reset"
+      <v-stepper
+        v-model="step"
+        alt-labels
       >
-        {{ $t('btn.reset') }}
-      </gokb-button>
-      <gokb-button
-        v-show="step !== 1"
-        @click="go2PreviousStep"
-      >
-        {{ $t('btn.back') }}
-      </gokb-button>
-      <v-spacer />
-      <div v-if="id">
-        <v-chip
-          class="ma-1"
-          label
-        >
-          <v-icon
-            :title="$t('component.general.dateCreated')"
-            class="pb-1"
-            medium
+        <v-stepper-header>
+          <v-stepper-step
+            editable
+            :step="1"
           >
-            mdi-file-plus-outline
-          </v-icon>
-          <span class="ml-1">{{ localDateCreated }}</span>
-        </v-chip>
-        <v-chip
-          class="ma-1"
-          label
+            {{ isEdit ? $t('component.package.navigation.step4') : $t('component.package.navigation.step1') }}
+          </v-stepper-step>
+          <v-divider />
+          <v-stepper-step
+            :editable="currentStepValid"
+            :class="{ error: !!step2Error }"
+            :step="2"
+          >
+            {{ isEdit ? $t('component.package.navigation.step1') : $t('component.package.navigation.step2') }}
+          </v-stepper-step>
+          <v-divider />
+          <v-stepper-step
+            :editable="currentStepValid"
+            :class="{ error: !!step3Error }"
+            :step="3"
+          >
+            {{ isEdit ? $t('component.package.navigation.step2') : $t('component.package.navigation.step3') }}
+          </v-stepper-step>
+          <v-divider />
+          <v-stepper-step
+            :editable="currentStepValid"
+            :step="4"
+          >
+            {{ isEdit ? $t('component.package.navigation.step3') : $t('component.package.navigation.step4') }}
+          </v-stepper-step>
+        </v-stepper-header>
+
+        <v-stepper-items>
+          <v-stepper-content :step="isEdit ? 2 : 1">
+            <gokb-section :no-tool-bar="true">
+              <gokb-name-field
+                v-model="allNames"
+                :disabled="isReadonly"
+                :required="!isReadonly"
+                check-dupes="Package"
+                :item-id="packageItem.id"
+              />
+              <gokb-url-field
+                v-model="packageItem.descriptionURL"
+                :disabled="isReadonly"
+                :label="$t('component.package.descriptionUrl')"
+              />
+              <gokb-textarea-field
+                ref="descEdit"
+                v-model="packageItem.description"
+                :label="$t('component.package.description')"
+                :disabled="isReadonly"
+              />
+            </gokb-section>
+            <v-row>
+              <v-col
+                cols="12"
+                xl="6"
+              >
+                <gokb-section
+                  :sub-title="$t('component.package.provider')"
+                  :mark-required="!isReadonly"
+                >
+                  <gokb-search-organisation-field
+                    v-model="packageItem.provider"
+                    :items="providerSelection"
+                    :show-link="true"
+                    :readonly="isReadonly"
+                    return-object
+                  />
+                </gokb-section>
+              </v-col>
+              <v-col
+                cols="12"
+                xl="6"
+              >
+                <gokb-section
+                  :sub-title="$t('component.package.platform')"
+                  :mark-required="!isReadonly"
+                >
+                  <gokb-search-platform-field
+                    v-model="packageItem.nominalPlatform"
+                    :items="platformSelection"
+                    :readonly="isReadonly"
+                    return-object
+                  />
+                </gokb-section>
+              </v-col>
+            </v-row>
+          </v-stepper-content>
+
+          <v-stepper-content :step="isEdit ? 3 : 2">
+            <gokb-section :no-tool-bar="true">
+              <v-row
+                class="pt-4"
+                dense
+              >
+                <v-col>
+                  <gokb-state-field
+                    v-model="packageItem.scope"
+                    :init-item="packageItem.scope"
+                    width="100%"
+                    message-path="component.package.scope"
+                    url="refdata/categories/Package.Scope"
+                    :label="$t('component.package.scope.label')"
+                    :readonly="isReadonly"
+                    dense
+                  />
+                </v-col>
+                <v-col>
+                  <gokb-state-field
+                    v-model="packageItem.contentType"
+                    :init-item="packageItem.contentType"
+                    width="100%"
+                    message-path="component.package.contentType"
+                    url="refdata/categories/Package.ContentType"
+                    :label="$t('component.package.contentType.label')"
+                    :readonly="isReadonly"
+                    dense
+                  />
+                </v-col>
+                <v-col>
+                  <gokb-state-field
+                    v-if="!!id"
+                    v-model="packageItem.editStatus"
+                    :init-item="packageItem.editStatus"
+                    message-path="component.general.editStatus"
+                    url="refdata/categories/KBComponent.EditStatus"
+                    width="100%"
+                    :label="$t('component.general.editStatus.label')"
+                    :readonly="isReadonly"
+                    dense
+                  />
+                </v-col>
+                <v-col>
+                  <gokb-state-field
+                    v-if="!!id"
+                    v-model="packageItem.listStatus"
+                    message-path="component.package.listStatus"
+                    url="refdata/categories/Package.ListStatus"
+                    width="100%"
+                    :label="$t('component.package.listStatus.label')"
+                    :readonly="isReadonly"
+                    dense
+                  />
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col cols="7">
+                  <div>
+                    <label for="validity">{{ $t('component.package.global.label') }}</label>
+                  </div>
+                  <gokb-radiobutton-group
+                    id="validity"
+                    v-model="packageItem.global"
+                  >
+                    <gokb-radiobutton-field
+                      value="Global"
+                      :label="$t('component.package.global.Global.label')"
+                      :readonly="isReadonly"
+                    />
+                    <gokb-radiobutton-field
+                      value="Consortium"
+                      :label="$t('component.package.global.Consortium.label')"
+                      :readonly="isReadonly"
+                    />
+                    <gokb-radiobutton-field
+                      value="Regional"
+                      :label="$t('component.package.global.Regional.label')"
+                      :readonly="isReadonly"
+                    />
+                    <gokb-radiobutton-field
+                      value="Other"
+                      :label="$t('component.package.global.Other.label')"
+                      :readonly="isReadonly"
+                    />
+                    <gokb-radiobutton-field
+                      value="Local"
+                      :label="$t('component.package.global.Local.label')"
+                      :readonly="isReadonly"
+                    />
+                  </gokb-radiobutton-group>
+                </v-col>
+                <v-col cols="1">
+                  <v-icon
+                    v-if="packageItem.global === 'Consortium' || packageItem.global === 'Regional' || packageItem.global === 'Other' || packageItem.global === 'Local'"
+                    class="mt-6"
+                  >
+                    mdi-chevron-triple-right
+                  </v-icon>
+                </v-col>
+                <v-col cols="4">
+                  <gokb-text-field
+                    v-if="packageItem.global === 'Consortium' || packageItem.global === 'Regional' || packageItem.global === 'Other' || packageItem.global === 'Local'"
+                    v-model="packageItem.globalNote"
+                    :label="$t('component.package.globalNote.label')"
+                    :disabled="isReadonly"
+                  />
+                </v-col>
+              </v-row>
+              <v-row>
+                <gokb-checkbox-field
+                  v-model="packageItem.consistent"
+                  class="ml-3"
+                  :label="$t('component.package.consistent')"
+                  :readonly="isReadonly"
+                />
+                <gokb-checkbox-field
+                  v-model="packageItem.breakable"
+                  class="ml-3"
+                  :label="$t('component.package.breakable')"
+                  :readonly="isReadonly"
+                />
+                <gokb-checkbox-field
+                  v-model="packageItem.fixed"
+                  class="ml-3"
+                  :label="$t('component.package.fixed')"
+                  :readonly="isReadonly"
+                />
+              </v-row>
+            </gokb-section>
+            <v-row>
+              <v-col
+                cols="12"
+                xl="6"
+              >
+                <gokb-identifier-section
+                  v-model="packageItem.ids"
+                  target-type="Package"
+                  :disabled="isReadonly"
+                  :api-errors="errors?.ids"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                xl="6"
+              >
+                <gokb-alternate-names-section
+                  v-model="allNames.alts"
+                  :disabled="isReadonly"
+                  :api-errors="errors?.variantNames"
+                />
+              </v-col>
+            </v-row>
+          </v-stepper-content>
+
+          <v-stepper-content :step="isEdit ? 4 : 3">
+            <v-row v-if="kbart && kbart.selectedFile">
+              <v-col>
+                <v-chip
+                  class="ml-6"
+                  close
+                  @click:close="kbart = undefined"
+                >
+                  {{ kbart.selectedFile.name }} ({{ kbart.lineCount }} {{ $tc('kbart.row.label', kbart.lineCount) }})
+                  <v-icon
+                    v-if="kbart.dryRun"
+                    class="ml-1"
+                    :title="$t('kbart.dryRun.label')"
+                    small
+                  >
+                    mdi-content-save-off
+                  </v-icon>
+                </v-chip>
+              </v-col>
+            </v-row>
+            <gokb-tipps-section
+              ref="tipps"
+              :pkg="id"
+              :filter-align="isEdit"
+              :platform="packageItem.nominalPlatform"
+              :provider="packageItem.provider"
+              :disabled="isReadonly"
+              :api-errors="errors?.tipps"
+              @kbart="setKbart"
+              @update="updateNewTipps"
+            />
+            <gokb-source-field
+              v-if="loggedIn"
+              ref="source"
+              v-model="sourceItem"
+              :default-title-namespace="providerTitleNamespace"
+              :expanded="false"
+              :api-errors="errors?.source"
+              :readonly="isReadonly"
+              @enable="triggerUpdate"
+            />
+          </v-stepper-content>
+
+          <v-stepper-content :step="isEdit ? 1 : 4">
+            <gokb-section :no-tool-bar="true">
+              <v-row>
+                <v-col>
+                  <gokb-name-field
+                    v-model="allNames"
+                    dense
+                    readonly
+                  />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col cols="6">
+                  <gokb-state-select-field
+                    v-if="packageItem.status"
+                    v-model="packageItem.status"
+                    dense
+                    :deletable="!isReadonly"
+                    :editable="!isReadonly"
+                    @delete="markDeleted"
+                  />
+                </v-col>
+                <v-col cols="6" xl="3">
+                  <gokb-uuid-field
+                    v-if="uuid"
+                    label="UUID"
+                    :value="uuid"
+                    path="/package"
+                    dense
+                  />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col>
+                  <gokb-text-field
+                    v-model="providerName"
+                    :label="$t('component.package.provider')"
+                    dense
+                    disabled
+                  />
+                </v-col>
+                <v-col>
+                  <gokb-text-field
+                    v-model="platformName"
+                    :label="$t('component.package.platform')"
+                    dense
+                    disabled
+                  />
+                </v-col>
+              </v-row>
+              <v-row v-if="packageItem.description">
+                <v-col>
+                  <gokb-textarea-field
+                    ref="descInfo"
+                    v-model="packageItem.description"
+                    :label="$t('component.package.description')"
+                    dense
+                    disabled
+                  />
+                </v-col>
+              </v-row>
+              <v-row v-if="id">
+                <v-col cols="3">
+                  <gokb-state-field
+                    v-model="overviewStates.contentType"
+                    :init-item="overviewStates.contentType"
+                    message-path="component.package.contentType"
+                    url="refdata/categories/Package.ContentType"
+                    :label="$t('component.package.contentType.label')"
+                    dense
+                    readonly
+                  />
+                </v-col>
+                <v-col cols="2">
+                  <gokb-number-field
+                    :value="totalNumberOfTitles"
+                    :label="$tc('component.tipp.label', 2)"
+                    dense
+                    disabled
+                  />
+                </v-col>
+                <v-col cols="3">
+                  <gokb-state-field
+                    v-model="overviewStates.listStatus"
+                    :init-item="overviewStates.listStatus"
+                    message-path="component.package.listStatus"
+                    url="refdata/categories/Package.ListStatus"
+                    :label="$t('component.package.listStatus.label')"
+                    :api-errors="errors?.listStatus"
+                    dense
+                    readonly
+                  />
+                </v-col>
+                <v-col>
+                  <gokb-text-field
+                    v-if="listVerifiedDate"
+                    v-model="localListVerifiedDate"
+                    :label="$t('component.package.listVerifiedDate.label')"
+                    dense
+                    disabled
+                  />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col v-if="kbart && kbart.selectedFile">
+                  <gokb-text-field
+                    v-model="kbart.selectedFile.name"
+                    :label="kbartLabel"
+                    dense
+                    disabled
+                  />
+                </v-col>
+              </v-row>
+            </gokb-section>
+            <gokb-section
+              v-if="maintenance"
+              :sub-title="$tc('component.maintenance.label', 2)"
+            >
+              <gokb-maintenance-cycle-field v-model="maintenanceCycle" />
+              <gokb-date-field
+                v-model="dueTo"
+                label="Fällig am"
+                disabled
+              />
+            </gokb-section>
+            <v-row>
+              <v-col
+                cols="12"
+                xl="5"
+              >
+                <gokb-curatory-group-section
+                  v-model="allCuratoryGroups"
+                  :disabled="!isAdmin"
+                  :filter-align="false"
+                  :expandable="false"
+                  :sub-title="$tc('component.curatoryGroup.label', 2)"
+                />
+              </v-col>
+              <v-col
+                cols="12"
+                xl="7"
+              >
+                <gokb-reviews-section
+                  v-if="id && isContrib"
+                  :expandable="false"
+                  :review-component="packageItem"
+                  :api-errors="errors?.listStatus"
+                  @update=reload
+                />
+              </v-col>
+            </v-row>
+            <v-row v-if="id && !isReadonly">
+              <v-col>
+                <gokb-jobs-section
+                  :linked-component="id"
+                  :hide-default="true"
+                  :auto-refresh="false"
+                />
+              </v-col>
+            </v-row>
+          </v-stepper-content>
+        </v-stepper-items>
+      </v-stepper>
+
+      <template #buttons>
+        <gokb-confirmation-popup
+          v-model="showSubmitConfirm"
+          :message="submitConfirmationMessage"
+          @confirmed="submitPackage"
+        />
+        <gokb-button
+          v-if="!isReadonly"
+          @click="reset"
         >
-          <v-icon
-            :title="$t('component.general.lastUpdated')"
-            class="pb-1"
+          {{ $t('btn.reset') }}
+        </gokb-button>
+        <gokb-button
+          v-show="step !== 1"
+          @click="go2PreviousStep"
+        >
+          {{ $t('btn.back') }}
+        </gokb-button>
+        <v-spacer />
+        <div v-if="id">
+          <v-chip
+            class="ma-1"
             label
-            medium
           >
-            mdi-refresh
-          </v-icon>
-          <span class="ml-1">{{ localLastUpdated }}</span>
-        </v-chip>
-      </div>
-      <v-spacer />
-      <gokb-button
-        v-if="!isInLastStep"
-        color="primary"
-        :disabled="!currentStepValid"
-        @click="go2NextStep"
-      >
-        {{ $t('btn.next') }}
-      </gokb-button>
-      <!-- without key, submit is executed on previous page -->
-      <gokb-button
-        v-else-if="!isReadonly"
-        key="add"
-        :disabled="!isValid"
-        default
-      >
-        {{ $i18n.t('btn.submit') }}
-      </gokb-button>
-    </template>
-  </gokb-page>
-  <gokb-no-access-field v-else-if="!accessible" />
-  <gokb-page
-    v-else
-    title=""
-  >
-    <v-card>
-      <v-card-text>
-        <div class="text-h5 primary--text">
-          {{ $t('component.general.notFound', [$tc('component.package.label')]) }}
+            <v-icon
+              :title="$t('component.general.dateCreated')"
+              class="pb-1"
+              medium
+            >
+              mdi-file-plus-outline
+            </v-icon>
+            <span class="ml-1">{{ localDateCreated }}</span>
+          </v-chip>
+          <v-chip
+            class="ma-1"
+            label
+          >
+            <v-icon
+              :title="$t('component.general.lastUpdated')"
+              class="pb-1"
+              label
+              medium
+            >
+              mdi-refresh
+            </v-icon>
+            <span class="ml-1">{{ localLastUpdated }}</span>
+          </v-chip>
         </div>
-      </v-card-text>
-    </v-card>
-  </gokb-page>
+        <v-spacer />
+        <gokb-button
+          v-if="!isInLastStep"
+          color="primary"
+          :disabled="!currentStepValid"
+          @click="go2NextStep"
+        >
+          {{ $t('btn.next') }}
+        </gokb-button>
+        <!-- without key, submit is executed on previous page -->
+        <gokb-button
+          v-else-if="!isReadonly"
+          key="add"
+          :disabled="!isValid"
+          default
+        >
+          {{ $i18n.t('btn.submit') }}
+        </gokb-button>
+      </template>
+    </gokb-page>
+    <gokb-no-access-field v-else-if="!accessible" />
+    <gokb-page
+      v-else
+      title=""
+    >
+      <v-card>
+        <v-card-text>
+          <div class="text-h5 primary--text">
+            {{ $t('component.general.notFound', [$tc('component.package.label')]) }}
+          </div>
+        </v-card-text>
+      </v-card>
+    </gokb-page>
+  </div>
 </template>
 
 <script>
@@ -905,7 +907,7 @@
           this.eventMessages.push({
             message: this.$i18n.t(this.initMessageCode, [this.$i18n.tc('component.package.label'), this.allNames.name]),
             color: 'success',
-            timeout: 2000
+            timeout: 4000
           })
         } else if (this.initMessageCode.includes('failure')) {
           this.eventMessages.push({
@@ -1136,7 +1138,7 @@
                 this.eventMessages.push({
                   message: this.$i18n.t(this.isEdit ? 'success.update' : 'success.create', [this.$i18n.tc('component.package.label'), this.allNames.name]),
                   color: 'success',
-                  timeout: 2000
+                  timeout: 4000
                 })
                 this.reload()
 
@@ -1193,7 +1195,7 @@
                 this.eventMessages.push({
                   message: this.$i18n.t(this.isEdit ? 'success.update' : 'success.create', [this.$i18n.tc('component.package.label'), this.allNames.name]),
                   color: 'success',
-                  timeout: 2000
+                  timeout: 4000
                 })
                 this.reload()
 
@@ -1217,7 +1219,7 @@
                 this.eventMessages.push({
                   message: this.$i18n.t((this.isEdit ? 'success.update' : 'success.create'), [this.$i18n.tc('component.package.label'), this.allNames.name]),
                   color: 'success',
-                  timeout: 2000
+                  timeout: 4000
                 })
               } else {
                 this.$router.push({

--- a/src/views/edit/edit-provider-view.vue
+++ b/src/views/edit/edit-provider-view.vue
@@ -1,365 +1,367 @@
 <template>
-  <gokb-page
-    v-if="accessible && !notFound"
-    :key="version"
-    :title="title"
-    @valid="valid = $event"
-    @submit="update"
-  >
-    <gokb-error-component :value="error" />
+  <div>
     <v-snackbars :objects.sync="eventMessages">
       <template #action="{ close }">
         <v-btn icon @click="close()"><v-icon>mdi-close</v-icon></v-btn>
       </template>
     </v-snackbars>
-    <gokb-section :no-tool-bar="true">
-      <v-row>
-        <v-col md="12">
-          <gokb-name-field
-            v-model="allNames"
-            :disabled="isReadonly"
-            :label="$t('component.general.name')"
-            check-dupes="Org"
-            :item-id="providerObject.id"
-          />
-        </v-col>
-      </v-row>
-      <v-row v-if="id">
-        <v-col cols="6">
-          <gokb-state-select-field
-            v-model="providerObject.status"
-            :deletable="!isReadonly"
-            :editable="!isReadonly"
-            @delete="markDeleted"
-          />
-        </v-col>
-        <v-col cols="6" xl="3">
-          <gokb-uuid-field
-            v-if="id"
-            :label="$t('component.general.uuid.label')"
-            :value="uuid"
-            path="/provider"
-            dense
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col cols="2">
-          <gokb-text-field
-            v-model="providerObject.preferredShortname"
-            :label="$t('component.provider.preferredShortname.label')"
-            :disabled="isReadonly"
-          />
-        </v-col>
-        <v-col cols="4">
-          <gokb-text-field
-            v-model="providerObject.homepage"
-            :label="$t('component.provider.homepage.label')"
-            :disabled="isReadonly"
-          />
-        </v-col>
-        <v-col cols="3" xl="2">
-          <gokb-namespace-field
-            v-model="providerObject.titleNamespace"
-            target-type="Title"
-            :readonly="isReadonly"
-            :label="$t('component.provider.titleNamespace.label')"
-          />
-        </v-col>
-        <v-col cols="3" xl="2">
-          <gokb-namespace-field
-            v-model="providerObject.packageNamespace"
-            target-type="Package"
-            :readonly="isReadonly"
-            :label="$t('component.provider.packageNamespace.label')"
-          />
-        </v-col>
-        <v-col lg="2" />
-      </v-row>
-    </gokb-section>
-    <v-row
-      v-if="tabsView"
-      :style="{ minHeight:'330px' }"
+    <gokb-page
+      v-if="accessible && !notFound"
+      :key="version"
+      :title="title"
+      @valid="valid = $event"
+      @submit="update"
     >
-      <v-col>
-        <v-tabs
-          v-model="tab"
-          class="mx-4"
-        >
-          <v-tabs-slider color="primary" />
+      <gokb-error-component :value="error" />
+      <gokb-section :no-tool-bar="true">
+        <v-row>
+          <v-col md="12">
+            <gokb-name-field
+              v-model="allNames"
+              :disabled="isReadonly"
+              :label="$t('component.general.name')"
+              check-dupes="Org"
+              :item-id="providerObject.id"
+            />
+          </v-col>
+        </v-row>
+        <v-row v-if="id">
+          <v-col cols="6">
+            <gokb-state-select-field
+              v-model="providerObject.status"
+              :deletable="!isReadonly"
+              :editable="!isReadonly"
+              @delete="markDeleted"
+            />
+          </v-col>
+          <v-col cols="6" xl="3">
+            <gokb-uuid-field
+              v-if="id"
+              :label="$t('component.general.uuid.label')"
+              :value="uuid"
+              path="/provider"
+              dense
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="2">
+            <gokb-text-field
+              v-model="providerObject.preferredShortname"
+              :label="$t('component.provider.preferredShortname.label')"
+              :disabled="isReadonly"
+            />
+          </v-col>
+          <v-col cols="4">
+            <gokb-text-field
+              v-model="providerObject.homepage"
+              :label="$t('component.provider.homepage.label')"
+              :disabled="isReadonly"
+            />
+          </v-col>
+          <v-col cols="3" xl="2">
+            <gokb-namespace-field
+              v-model="providerObject.titleNamespace"
+              target-type="Title"
+              :readonly="isReadonly"
+              :label="$t('component.provider.titleNamespace.label')"
+            />
+          </v-col>
+          <v-col cols="3" xl="2">
+            <gokb-namespace-field
+              v-model="providerObject.packageNamespace"
+              target-type="Package"
+              :readonly="isReadonly"
+              :label="$t('component.provider.packageNamespace.label')"
+            />
+          </v-col>
+          <v-col lg="2" />
+        </v-row>
+      </gokb-section>
+      <v-row
+        v-if="tabsView"
+        :style="{ minHeight:'330px' }"
+      >
+        <v-col>
+          <v-tabs
+            v-model="tab"
+            class="mx-4"
+          >
+            <v-tabs-slider color="primary" />
 
-          <v-tab
-            key="variants"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.variantName.label', 2) }}
-            <v-chip class="ma-2">
-              {{ allNames.alts.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.variants"
-              :title="$t('pending.lists.changed')"
-              small
+            <v-tab
+              key="variants"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            key="identifiers"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.identifier.label', 2) }}
-            <v-chip class="ma-2">
-              {{ providerObject.ids.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.ids"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.variantName.label', 2) }}
+              <v-chip class="ma-2">
+                {{ allNames.alts.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.variants"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              key="identifiers"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            key="platforms"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.platform.label', 2) }}
-            <v-chip class="ma-2">
-              {{ allPlatforms.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.platforms"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.identifier.label', 2) }}
+              <v-chip class="ma-2">
+                {{ providerObject.ids.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.ids"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              key="platforms"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            v-if="!!id"
-            key="packages"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.package.label', 2) }}
-            <v-chip class="ma-2">
-              {{ packageCount }}
-            </v-chip>
-          </v-tab>
-          <v-tab
-            key="curators"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.curatoryGroup.label', 2) }}
-            <v-chip class="ma-2">
-              {{ allCuratoryGroups.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.curators"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.platform.label', 2) }}
+              <v-chip class="ma-2">
+                {{ allPlatforms.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.platforms"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              v-if="!!id"
+              key="packages"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            key="offices"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.office.label', 2) }}
-            <v-chip class="ma-2">
-              {{ offices.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.offices"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.package.label', 2) }}
+              <v-chip class="ma-2">
+                {{ packageCount }}
+              </v-chip>
+            </v-tab>
+            <v-tab
+              key="curators"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-        </v-tabs>
-        <v-tabs-items
-          v-model="tab"
-        >
-          <v-tab-item
-            key="variants"
-            class="mt-4"
+              {{ $tc('component.curatoryGroup.label', 2) }}
+              <v-chip class="ma-2">
+                {{ allCuratoryGroups.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.curators"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              key="offices"
+              :active-class="tabClass"
+            >
+              {{ $tc('component.office.label', 2) }}
+              <v-chip class="ma-2">
+                {{ offices.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.offices"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+          </v-tabs>
+          <v-tabs-items
+            v-model="tab"
           >
-            <gokb-alternate-names-section
-              v-model="allNames.alts"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.variantNames"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="identifiers"
-            class="mt-4"
-          >
-            <gokb-identifier-section
-              v-model="providerObject.ids"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.ids"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="platforms"
-            class="mt-4"
-          >
-            <gokb-platform-section
-              v-model="allPlatforms"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.providedPlatforms"
-              :provider-id="providerObject.id"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            v-if="!!id"
-            key="packages"
-            class="mt-4"
-          >
-            <gokb-packages-section
-              :show-title="false"
-              disabled
-              :api-errors="errors.providedPackages"
-              :provider-id="providerObject.id"
-              @update="updatePackageCount"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="curators"
-            class="mt-4"
-          >
-            <gokb-curatory-group-section
-              v-model="allCuratoryGroups"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.curatoryGroups"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="offices"
-            class="mt-4"
-          >
-            <gokb-offices-section
-              v-model="offices"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.offices"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-        </v-tabs-items>
-      </v-col>
-    </v-row>
-    <div v-else>
-      <gokb-alternate-names-section
-        v-model="allNames.alts"
-        :expanded="allNames.alts.length > 0"
-        :disabled="isReadonly"
-      />
-      <gokb-identifier-section
-        v-model="providerObject.ids"
-        :expanded="providerObject.ids.length > 0"
-        :disabled="isReadonly"
-      />
-      <gokb-platform-section
-        v-model="allPlatforms"
-        :expanded="allPlatforms.length > 0"
-        :sub-title="$tc('component.platform.label', 2)"
-        :disabled="isReadonly"
-      />
-      <gokb-packages-section
-        v-if="!!id"
-        :sub-title="$tc('component.package.label', 2)"
-        :expanded="packageCount > 0"
-        disabled
-      />
-      <gokb-curatory-group-section
-        v-model="allCuratoryGroups"
-        :expanded="allCuratoryGroups.length > 0"
-        :sub-title="$tc('component.curatoryGroup.label', 2)"
-        :disabled="isReadonly"
-      />
-      <gokb-offices-section
-        v-model="offices"
-        :expanded="offices.length > 0"
-        :sub-title="$tc('component.office.label', 2)"
-        :disabled="isReadonly"
-      />
-    </div>
-    <template #buttons>
-      <gokb-button
-        v-if="!isReadonly"
-        @click="reset"
-      >
-        {{ $t('btn.reset') }}
-      </gokb-button>
-      <v-spacer />
-      <div v-if="id">
-        <v-chip
-          class="ma-1"
-          label
-        >
-          <v-icon
-            :title="$t('component.general.dateCreated')"
-            class="pb-1"
-            medium
-          >
-            mdi-file-plus-outline
-          </v-icon>
-          <span class="ml-1">{{ localDateCreated }}</span>
-        </v-chip>
-        <v-chip
-          class="ma-1"
-          label
-        >
-          <v-icon
-            :title="$t('component.general.lastUpdated')"
-            class="pb-1"
-            label
-            medium
-          >
-            mdi-refresh
-          </v-icon>
-          <span class="ml-1">{{ localLastUpdated }}</span>
-        </v-chip>
+            <v-tab-item
+              key="variants"
+              class="mt-4"
+            >
+              <gokb-alternate-names-section
+                v-model="allNames.alts"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.variantNames"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="identifiers"
+              class="mt-4"
+            >
+              <gokb-identifier-section
+                v-model="providerObject.ids"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.ids"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="platforms"
+              class="mt-4"
+            >
+              <gokb-platform-section
+                v-model="allPlatforms"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.providedPlatforms"
+                :provider-id="providerObject.id"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              v-if="!!id"
+              key="packages"
+              class="mt-4"
+            >
+              <gokb-packages-section
+                :show-title="false"
+                disabled
+                :api-errors="errors.providedPackages"
+                :provider-id="providerObject.id"
+                @update="updatePackageCount"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="curators"
+              class="mt-4"
+            >
+              <gokb-curatory-group-section
+                v-model="allCuratoryGroups"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.curatoryGroups"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="offices"
+              class="mt-4"
+            >
+              <gokb-offices-section
+                v-model="offices"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.offices"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+          </v-tabs-items>
+        </v-col>
+      </v-row>
+      <div v-else>
+        <gokb-alternate-names-section
+          v-model="allNames.alts"
+          :expanded="allNames.alts.length > 0"
+          :disabled="isReadonly"
+        />
+        <gokb-identifier-section
+          v-model="providerObject.ids"
+          :expanded="providerObject.ids.length > 0"
+          :disabled="isReadonly"
+        />
+        <gokb-platform-section
+          v-model="allPlatforms"
+          :expanded="allPlatforms.length > 0"
+          :sub-title="$tc('component.platform.label', 2)"
+          :disabled="isReadonly"
+        />
+        <gokb-packages-section
+          v-if="!!id"
+          :sub-title="$tc('component.package.label', 2)"
+          :expanded="packageCount > 0"
+          disabled
+        />
+        <gokb-curatory-group-section
+          v-model="allCuratoryGroups"
+          :expanded="allCuratoryGroups.length > 0"
+          :sub-title="$tc('component.curatoryGroup.label', 2)"
+          :disabled="isReadonly"
+        />
+        <gokb-offices-section
+          v-model="offices"
+          :expanded="offices.length > 0"
+          :sub-title="$tc('component.office.label', 2)"
+          :disabled="isReadonly"
+        />
       </div>
-      <v-spacer />
-      <v-switch
-        v-model="tabsView"
-        class="pt-4 pr-6"
-        :label="$t('component.title.tabsView')"
-      />
-      <gokb-button
-        v-if="!isReadonly"
-        :disabled="!valid"
-        default
-      >
-        {{ updateButtonText }}
-      </gokb-button>
-    </template>
-  </gokb-page>
-  <gokb-no-access-field v-else-if="!accessible" />
-  <gokb-page
-    v-else
-    title=""
-  >
-    <v-card>
-      <v-card-text>
-        <div class="text-h5 primary--text">
-          {{ $t('component.general.notFound', [$tc('component.provider.label')]) }}
+      <template #buttons>
+        <gokb-button
+          v-if="!isReadonly"
+          @click="reset"
+        >
+          {{ $t('btn.reset') }}
+        </gokb-button>
+        <v-spacer />
+        <div v-if="id">
+          <v-chip
+            class="ma-1"
+            label
+          >
+            <v-icon
+              :title="$t('component.general.dateCreated')"
+              class="pb-1"
+              medium
+            >
+              mdi-file-plus-outline
+            </v-icon>
+            <span class="ml-1">{{ localDateCreated }}</span>
+          </v-chip>
+          <v-chip
+            class="ma-1"
+            label
+          >
+            <v-icon
+              :title="$t('component.general.lastUpdated')"
+              class="pb-1"
+              label
+              medium
+            >
+              mdi-refresh
+            </v-icon>
+            <span class="ml-1">{{ localLastUpdated }}</span>
+          </v-chip>
         </div>
-      </v-card-text>
-    </v-card>
-  </gokb-page>
+        <v-spacer />
+        <v-switch
+          v-model="tabsView"
+          class="pt-4 pr-6"
+          :label="$t('component.title.tabsView')"
+        />
+        <gokb-button
+          v-if="!isReadonly"
+          :disabled="!valid"
+          default
+        >
+          {{ updateButtonText }}
+        </gokb-button>
+      </template>
+    </gokb-page>
+    <gokb-no-access-field v-else-if="!accessible" />
+    <gokb-page
+      v-else
+      title=""
+    >
+      <v-card>
+        <v-card-text>
+          <div class="text-h5 primary--text">
+            {{ $t('component.general.notFound', [$tc('component.provider.label')]) }}
+          </div>
+        </v-card-text>
+      </v-card>
+    </gokb-page>
+  </div>
 </template>
 
 <script>

--- a/src/views/edit/edit-tipp-view.vue
+++ b/src/views/edit/edit-tipp-view.vue
@@ -1,551 +1,553 @@
 <template>
-  <gokb-page
-    v-if="!notFound"
-    :key="version"
-    :title="$tc('component.tipp.label')"
-    @submit="update"
-  >
-    <gokb-error-component :value="error" />
+  <div>
     <v-snackbars :objects.sync="eventMessages">
       <template #action="{ close }">
         <v-btn icon @click="close()"><v-icon>mdi-close</v-icon></v-btn>
       </template>
     </v-snackbars>
-    <gokb-section :sub-title="$t('component.general.general')">
-      <v-row>
-        <v-col>
-          <gokb-name-field
-            v-model="allNames"
-            :disabled="isReadonly"
-            :label="$tc('component.tipp.name')"
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col cols="6">
-          <gokb-state-select-field
-            v-if="status"
-            v-model="packageTitleItem.status"
-            :deletable="!isReadonly"
-            :editable="!isReadonly"
-            @delete="markDeleted"
-          />
-        </v-col>
-        <v-col cols="6" xl="3">
-          <gokb-uuid-field
-            v-if="id"
-            :label="$t('component.general.uuid.label')"
-            :value="uuid"
-            path="/package-title"
-            dense
-          />
-        </v-col>
-      </v-row>
-      <v-row dense>
-        <v-col>
-          <gokb-title-field
-            v-model="packageTitleItem.title"
-            :label="titleLabel"
-            :readonly="isReadonly"
-            return-object
-            show-link
-          />
-        </v-col>
-      </v-row>
-      <v-row dense>
-        <v-col>
-          <gokb-search-package-field
-            v-model="packageTitleItem.pkg"
-            :label="$tc('component.package.label')"
-            :readonly="true"
-            return-object
-          />
-        </v-col>
-      </v-row>
-      <v-row class="pb-4" />
-    </gokb-section>
-    <v-row style="min-height:410px">
-      <v-col>
-        <v-tabs
-          v-model="tab"
-          class="mx-4"
-        >
-          <v-tabs-slider color="black" />
-          <v-tab
-            key="access"
-            :active-class="tabClass"
-          >
-            {{ $t('component.tipp.access.label') }}
-          </v-tab>
-          <v-tab
-            key="coverage"
-            :active-class="tabClass"
-          >
-            {{ $t('component.tipp.coverage.label') }}
-            <v-icon
-              v-if="pendingChanges.coverage"
-              class="pb-1"
-              :title="$t('pending.lists.changed')"
-              small
-            >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            key="identifiers"
-            :style="[!!errors.ids ? { border: '1px solid red', borderRadius: '2px' } : {}]"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.identifier.label', 2) }}
-            <v-chip
+    <gokb-page
+      v-if="!notFound"
+      :key="version"
+      :title="$tc('component.tipp.label')"
+      @submit="update"
+    >
+      <gokb-error-component :value="error" />
+      <gokb-section :sub-title="$t('component.general.general')">
+        <v-row>
+          <v-col>
+            <gokb-name-field
+              v-model="allNames"
+              :disabled="isReadonly"
+              :label="$tc('component.tipp.name')"
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="6">
+            <gokb-state-select-field
+              v-if="status"
+              v-model="packageTitleItem.status"
+              :deletable="!isReadonly"
+              :editable="!isReadonly"
+              @delete="markDeleted"
+            />
+          </v-col>
+          <v-col cols="6" xl="3">
+            <gokb-uuid-field
               v-if="id"
-              class="ma-2"
-            >
-              {{ idsTotal }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.ids"
-              :title="$t('pending.lists.changed')"
-              small
-            >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            v-if="id && loggedIn"
-            key="reviews"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.review.label', 2) }}
-            <v-chip
-              v-if="id"
-              class="ma-2"
-            >
-              {{ reviewsCount }}
-            </v-chip>
-          </v-tab>
-          <v-tab
-            key="other"
-            :active-class="tabClass"
-          >
-            {{ $t('component.tipp.other.label') }}
-          </v-tab>
-          <v-tab
-            key="prices"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.tipp.prices.label', 2) }}
-          </v-tab>
-        </v-tabs>
-        <v-tabs-items v-model="tab">
-          <v-tab-item key="access">
-            <gokb-section no-tool-bar>
-              <v-row dense>
-                <v-col>
-                  <gokb-search-platform-field
-                    v-model="packageTitleItem.hostPlatform"
-                    :items="platformSelection"
-                    :label="$tc('component.platform.label')"
-                    :readonly="isEdit || isReadonly"
-                    :query-fields="platformQueryFields"
-                    return-object
-                  />
-                </v-col>
-              </v-row>
-              <v-row>
-                <v-col>
-                  <gokb-date-field
-                    v-model="packageTitleItem.accessStartDate"
-                    :readonly="isReadonly"
-                    :label="$t('component.tipp.accessStartDate')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-date-field
-                    v-model="packageTitleItem.accessEndDate"
-                    :readonly="isReadonly"
-                    :label="$t('component.tipp.accessEndDate')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-state-field
-                    v-model="packageTitleItem.paymentType"
-                    :init-item="packageTitleItem.paymentType"
-                    message-path="component.tipp.paymentType"
-                    url="refdata/categories/TitleInstancePackagePlatform.PaymentType"
-                    :label="$t('component.tipp.paymentType.label')"
-                    :readonly="isReadonly"
-                  />
-                </v-col>
-              </v-row>
-              <v-row>
-                <v-col>
-                  <gokb-url-field
-                    v-model="packageTitleItem.url"
-                    :disabled="isReadonly"
-                    :label="$tc('component.tipp.url.label')"
-                  />
-                </v-col>
-              </v-row>
-            </gokb-section>
-          </v-tab-item>
-          <v-tab-item key="coverage">
-            <v-toolbar
+              :label="$t('component.general.uuid.label')"
+              :value="uuid"
+              path="/package-title"
               dense
-              flat
+            />
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col>
+            <gokb-title-field
+              v-model="packageTitleItem.title"
+              :label="titleLabel"
+              :readonly="isReadonly"
+              return-object
+              show-link
+            />
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col>
+            <gokb-search-package-field
+              v-model="packageTitleItem.pkg"
+              :label="$tc('component.package.label')"
+              :readonly="true"
+              return-object
+            />
+          </v-col>
+        </v-row>
+        <v-row class="pb-4" />
+      </gokb-section>
+      <v-row style="min-height:410px">
+        <v-col>
+          <v-tabs
+            v-model="tab"
+            class="mx-4"
+          >
+            <v-tabs-slider color="black" />
+            <v-tab
+              key="access"
+              :active-class="tabClass"
             >
-              <span class="text-h6">
-                {{ $t('component.tipp.coverage.label') }}
-              </span>
-              <v-spacer />
-              <v-toolbar-items class="pa-2">
-                <gokb-button
-                  v-if="!isReadonly"
-                  icon-id="mdi-plus"
-                  @click="addNewCoverage"
-                >
-                  {{ $t('btn.add') }}
-                </gokb-button>
-              </v-toolbar-items>
-            </v-toolbar>
-            <v-row
-              v-for="(statement, idx) in packageTitleItem.coverageStatements"
-              :key="idx"
-              dense
+              {{ $t('component.tipp.access.label') }}
+            </v-tab>
+            <v-tab
+              key="coverage"
+              :active-class="tabClass"
             >
-              <v-col>
-                <gokb-section no-tool-bar>
-                  <v-row>
-                    <v-col cols="4">
-                      <gokb-state-field
-                        v-model="statement.coverageDepth"
-                        :readonly="isReadonly"
-                        :init-item="statement.coverageDepth"
-                        :label="$t('component.tipp.coverage.depth.label')"
-                        message-path="component.tipp.coverage.depth"
-                        url="refdata/categories/TIPPCoverageStatement.CoverageDepth"
-                      />
-                    </v-col>
-                    <v-col>
-                      <gokb-textarea-field
-                        v-model="statement.coverageNote"
-                        :disabled="isReadonly"
-                        :label="$t('component.tipp.coverage.note')"
-                      />
-                    </v-col>
-                    <v-col
-                      v-if="!isReadonly"
-                      cols="1"
-                      class="pt-6"
-                    >
-                      <v-btn
-                        icon
-                        :title="$t('btn.delete')"
-                        @click="removeCoverage(idx)"
+              {{ $t('component.tipp.coverage.label') }}
+              <v-icon
+                v-if="pendingChanges.coverage"
+                class="pb-1"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              key="identifiers"
+              :style="[!!errors.ids ? { border: '1px solid red', borderRadius: '2px' } : {}]"
+              :active-class="tabClass"
+            >
+              {{ $tc('component.identifier.label', 2) }}
+              <v-chip
+                v-if="id"
+                class="ma-2"
+              >
+                {{ idsTotal }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.ids"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              v-if="id && loggedIn"
+              key="reviews"
+              :active-class="tabClass"
+            >
+              {{ $tc('component.review.label', 2) }}
+              <v-chip
+                v-if="id"
+                class="ma-2"
+              >
+                {{ reviewsCount }}
+              </v-chip>
+            </v-tab>
+            <v-tab
+              key="other"
+              :active-class="tabClass"
+            >
+              {{ $t('component.tipp.other.label') }}
+            </v-tab>
+            <v-tab
+              key="prices"
+              :active-class="tabClass"
+            >
+              {{ $tc('component.tipp.prices.label', 2) }}
+            </v-tab>
+          </v-tabs>
+          <v-tabs-items v-model="tab">
+            <v-tab-item key="access">
+              <gokb-section no-tool-bar>
+                <v-row dense>
+                  <v-col>
+                    <gokb-search-platform-field
+                      v-model="packageTitleItem.hostPlatform"
+                      :items="platformSelection"
+                      :label="$tc('component.platform.label')"
+                      :readonly="isEdit || isReadonly"
+                      :query-fields="platformQueryFields"
+                      return-object
+                    />
+                  </v-col>
+                </v-row>
+                <v-row>
+                  <v-col>
+                    <gokb-date-field
+                      v-model="packageTitleItem.accessStartDate"
+                      :readonly="isReadonly"
+                      :label="$t('component.tipp.accessStartDate')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-date-field
+                      v-model="packageTitleItem.accessEndDate"
+                      :readonly="isReadonly"
+                      :label="$t('component.tipp.accessEndDate')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-state-field
+                      v-model="packageTitleItem.paymentType"
+                      :init-item="packageTitleItem.paymentType"
+                      message-path="component.tipp.paymentType"
+                      url="refdata/categories/TitleInstancePackagePlatform.PaymentType"
+                      :label="$t('component.tipp.paymentType.label')"
+                      :readonly="isReadonly"
+                    />
+                  </v-col>
+                </v-row>
+                <v-row>
+                  <v-col>
+                    <gokb-url-field
+                      v-model="packageTitleItem.url"
+                      :disabled="isReadonly"
+                      :label="$tc('component.tipp.url.label')"
+                    />
+                  </v-col>
+                </v-row>
+              </gokb-section>
+            </v-tab-item>
+            <v-tab-item key="coverage">
+              <v-toolbar
+                dense
+                flat
+              >
+                <span class="text-h6">
+                  {{ $t('component.tipp.coverage.label') }}
+                </span>
+                <v-spacer />
+                <v-toolbar-items class="pa-2">
+                  <gokb-button
+                    v-if="!isReadonly"
+                    icon-id="mdi-plus"
+                    @click="addNewCoverage"
+                  >
+                    {{ $t('btn.add') }}
+                  </gokb-button>
+                </v-toolbar-items>
+              </v-toolbar>
+              <v-row
+                v-for="(statement, idx) in packageTitleItem.coverageStatements"
+                :key="idx"
+                dense
+              >
+                <v-col>
+                  <gokb-section no-tool-bar>
+                    <v-row>
+                      <v-col cols="4">
+                        <gokb-state-field
+                          v-model="statement.coverageDepth"
+                          :readonly="isReadonly"
+                          :init-item="statement.coverageDepth"
+                          :label="$t('component.tipp.coverage.depth.label')"
+                          message-path="component.tipp.coverage.depth"
+                          url="refdata/categories/TIPPCoverageStatement.CoverageDepth"
+                        />
+                      </v-col>
+                      <v-col>
+                        <gokb-textarea-field
+                          v-model="statement.coverageNote"
+                          :disabled="isReadonly"
+                          :label="$t('component.tipp.coverage.note')"
+                        />
+                      </v-col>
+                      <v-col
+                        v-if="!isReadonly"
+                        cols="1"
+                        class="pt-6"
                       >
-                        <v-icon>
-                          mdi-delete
-                        </v-icon>
-                      </v-btn>
-                    </v-col>
-                  </v-row>
-                  <v-row
-                    v-if="isJournal"
-                    dense
-                  >
-                    <v-col cols="4">
-                      <gokb-date-field
-                        v-model="statement.startDate"
-                        :readonly="isReadonly"
-                        dense
-                        :label="$t('component.tipp.coverage.startDate')"
-                      />
-                    </v-col>
-                    <v-col cols="4">
-                      <gokb-text-field
-                        v-model="statement.startVolume"
-                        :disabled="isReadonly"
-                        dense
-                        :label="$t('component.tipp.coverage.startVolume')"
-                      />
-                    </v-col>
-                    <v-col cols="4">
-                      <gokb-text-field
-                        v-model="statement.startIssue"
-                        :disabled="isReadonly"
-                        dense
-                        :label="$t('component.tipp.coverage.startIssue')"
-                      />
-                    </v-col>
-                  </v-row>
-                  <v-row
-                    v-if="isJournal"
-                    dense
-                  >
-                    <v-col cols="4">
-                      <gokb-date-field
-                        v-model="statement.endDate"
-                        :readonly="isReadonly"
-                        dense
-                        :label="$t('component.tipp.coverage.endDate')"
-                      />
-                    </v-col>
-                    <v-col cols="4">
-                      <gokb-text-field
-                        v-model="statement.endVolume"
-                        :disabled="isReadonly"
-                        dense
-                        :label="$t('component.tipp.coverage.endVolume')"
-                      />
-                    </v-col>
-                    <v-col cols="4">
-                      <gokb-text-field
-                        v-model="statement.endIssue"
-                        :disabled="isReadonly"
-                        dense
-                        :label="$t('component.tipp.coverage.endIssue')"
-                      />
-                    </v-col>
-                  </v-row>
-                  <v-row dense>
-                    <v-col>
-                      <gokb-embargo-field
-                        v-model="statement.embargo"
-                        dense
-                        :readonly="isReadonly"
-                      />
-                    </v-col>
-                  </v-row>
-                </gokb-section>
-              </v-col>
-            </v-row>
-          </v-tab-item>
-          <v-tab-item key="ids">
-            <gokb-identifier-section
-              v-model="packageTitleItem.ids"
-              :target-type="titleTypeString"
-              :api-errors="errors.ids"
-              :disabled="isReadonly"
-              no-tool-bar
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            v-if="id && loggedIn"
-            key="reviews"
-          >
-            <gokb-reviews-section
-              :review-component="packageTitleItem"
-              :show-title="false"
-              :api-errors="errors.reviewRequests"
-              :expandable="false"
-              @update="refreshReviewsCount"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="other"
-          >
-            <gokb-section no-tool-bar>
-              <v-row>
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.publisherName"
-                    :disabled="isReadonly"
-                    :label="$tc('component.title.publisher.label')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.series"
-                    :disabled="isReadonly"
-                    :label="$t('component.tipp.series.label')"
-                  />
+                        <v-btn
+                          icon
+                          :title="$t('btn.delete')"
+                          @click="removeCoverage(idx)"
+                        >
+                          <v-icon>
+                            mdi-delete
+                          </v-icon>
+                        </v-btn>
+                      </v-col>
+                    </v-row>
+                    <v-row
+                      v-if="isJournal"
+                      dense
+                    >
+                      <v-col cols="4">
+                        <gokb-date-field
+                          v-model="statement.startDate"
+                          :readonly="isReadonly"
+                          dense
+                          :label="$t('component.tipp.coverage.startDate')"
+                        />
+                      </v-col>
+                      <v-col cols="4">
+                        <gokb-text-field
+                          v-model="statement.startVolume"
+                          :disabled="isReadonly"
+                          dense
+                          :label="$t('component.tipp.coverage.startVolume')"
+                        />
+                      </v-col>
+                      <v-col cols="4">
+                        <gokb-text-field
+                          v-model="statement.startIssue"
+                          :disabled="isReadonly"
+                          dense
+                          :label="$t('component.tipp.coverage.startIssue')"
+                        />
+                      </v-col>
+                    </v-row>
+                    <v-row
+                      v-if="isJournal"
+                      dense
+                    >
+                      <v-col cols="4">
+                        <gokb-date-field
+                          v-model="statement.endDate"
+                          :readonly="isReadonly"
+                          dense
+                          :label="$t('component.tipp.coverage.endDate')"
+                        />
+                      </v-col>
+                      <v-col cols="4">
+                        <gokb-text-field
+                          v-model="statement.endVolume"
+                          :disabled="isReadonly"
+                          dense
+                          :label="$t('component.tipp.coverage.endVolume')"
+                        />
+                      </v-col>
+                      <v-col cols="4">
+                        <gokb-text-field
+                          v-model="statement.endIssue"
+                          :disabled="isReadonly"
+                          dense
+                          :label="$t('component.tipp.coverage.endIssue')"
+                        />
+                      </v-col>
+                    </v-row>
+                    <v-row dense>
+                      <v-col>
+                        <gokb-embargo-field
+                          v-model="statement.embargo"
+                          dense
+                          :readonly="isReadonly"
+                        />
+                      </v-col>
+                    </v-row>
+                  </gokb-section>
                 </v-col>
               </v-row>
-              <v-row dense>
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.subjectArea"
-                    :disabled="isReadonly"
-                    dense
-                    :label="$t('component.tipp.subjectArea.label')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-state-field
-                    v-model="packageTitleItem.medium"
-                    :init-item="packageTitleItem.medium"
-                    width="100%"
-                    dense
-                    message-path="component.title.medium"
-                    url="refdata/categories/TitleInstancePackagePlatform.Medium"
-                    :label="$t('component.title.medium.label')"
-                    :readonly="isReadonly"
-                  />
-                </v-col>
-              </v-row>
-              <v-row dense>
-                <v-col cols="6">
-                  <gokb-text-field
-                    v-model="importId"
-                    disabled
-                    dense
-                    :label="$t('component.tipp.importId.label')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-state-field
-                    v-model="packageTitleItem.publicationType"
-                    :init-item="packageTitleItem.publicationType"
-                    width="100%"
-                    dense
-                    return-object
-                    message-path="component.tipp.publicationType"
-                    url="refdata/categories/TitleInstancePackagePlatform.PublicationType"
-                    :label="$t('component.tipp.publicationType.label')"
-                    readonly
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-date-field
-                    v-model="packageTitleItem.lastChangedExternal"
-                    readonly
-                    dense
-                    :label="$t('component.tipp.lastChangedExternal')"
-                  />
-                </v-col>
-              </v-row>
-              <v-row
-                v-if="isBook"
-                dense
-              >
-                <v-col>
-                  <gokb-date-field
-                    v-model="packageTitleItem.dateFirstInPrint"
-                    :readonly="isReadonly"
-                    dense
-                    :label="$t('component.title.firstPublishedInPrint')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-date-field
-                    v-model="packageTitleItem.dateFirstOnline"
-                    :readonly="isReadonly"
-                    dense
-                    :label="$t('component.title.firstPublishedOnline')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.volumeNumber"
-                    :disabled="isReadonly"
-                    dense
-                    :label="$t('component.title.volumeNumber')"
-                  />
-                </v-col>
-              </v-row>
-              <v-row
-                v-if="isBook"
-                dense
-              >
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.firstAuthor"
-                    :disabled="isReadonly"
-                    dense
-                    :label="$t('component.title.firstAuthor.label')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.firstEditor"
-                    :disabled="isReadonly"
-                    dense
-                    :label="$t('component.title.firstEditor.label')"
-                  />
-                </v-col>
-                <v-col>
-                  <gokb-text-field
-                    v-model="packageTitleItem.editionStatement"
-                    :disabled="isReadonly"
-                    dense
-                    :label="$t('component.title.editionStatement')"
-                  />
-                </v-col>
-              </v-row>
-            </gokb-section>
-          </v-tab-item>
-          <v-tab-item key="prices">
-            <gokb-prices-section
-              v-model="packageTitleItem.prices"
-              :disabled="isReadonly"
-              no-tool-bar
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-        </v-tabs-items>
-      </v-col>
-    </v-row>
-    <template #buttons>
-      <gokb-button
-        v-if="!isReadonly"
-        @click="reset"
-      >
-        {{ $t('btn.reset') }}
-      </gokb-button>
-      <v-spacer />
-      <div v-if="id && !notFound">
-        <v-chip
-          class="ma-1"
-          label
+            </v-tab-item>
+            <v-tab-item key="ids">
+              <gokb-identifier-section
+                v-model="packageTitleItem.ids"
+                :target-type="titleTypeString"
+                :api-errors="errors.ids"
+                :disabled="isReadonly"
+                no-tool-bar
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              v-if="id && loggedIn"
+              key="reviews"
+            >
+              <gokb-reviews-section
+                :review-component="packageTitleItem"
+                :show-title="false"
+                :api-errors="errors.reviewRequests"
+                :expandable="false"
+                @update="refreshReviewsCount"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="other"
+            >
+              <gokb-section no-tool-bar>
+                <v-row>
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.publisherName"
+                      :disabled="isReadonly"
+                      :label="$tc('component.title.publisher.label')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.series"
+                      :disabled="isReadonly"
+                      :label="$t('component.tipp.series.label')"
+                    />
+                  </v-col>
+                </v-row>
+                <v-row dense>
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.subjectArea"
+                      :disabled="isReadonly"
+                      dense
+                      :label="$t('component.tipp.subjectArea.label')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-state-field
+                      v-model="packageTitleItem.medium"
+                      :init-item="packageTitleItem.medium"
+                      width="100%"
+                      dense
+                      message-path="component.title.medium"
+                      url="refdata/categories/TitleInstancePackagePlatform.Medium"
+                      :label="$t('component.title.medium.label')"
+                      :readonly="isReadonly"
+                    />
+                  </v-col>
+                </v-row>
+                <v-row dense>
+                  <v-col cols="6">
+                    <gokb-text-field
+                      v-model="importId"
+                      disabled
+                      dense
+                      :label="$t('component.tipp.importId.label')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-state-field
+                      v-model="packageTitleItem.publicationType"
+                      :init-item="packageTitleItem.publicationType"
+                      width="100%"
+                      dense
+                      return-object
+                      message-path="component.tipp.publicationType"
+                      url="refdata/categories/TitleInstancePackagePlatform.PublicationType"
+                      :label="$t('component.tipp.publicationType.label')"
+                      readonly
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-date-field
+                      v-model="packageTitleItem.lastChangedExternal"
+                      readonly
+                      dense
+                      :label="$t('component.tipp.lastChangedExternal')"
+                    />
+                  </v-col>
+                </v-row>
+                <v-row
+                  v-if="isBook"
+                  dense
+                >
+                  <v-col>
+                    <gokb-date-field
+                      v-model="packageTitleItem.dateFirstInPrint"
+                      :readonly="isReadonly"
+                      dense
+                      :label="$t('component.title.firstPublishedInPrint')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-date-field
+                      v-model="packageTitleItem.dateFirstOnline"
+                      :readonly="isReadonly"
+                      dense
+                      :label="$t('component.title.firstPublishedOnline')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.volumeNumber"
+                      :disabled="isReadonly"
+                      dense
+                      :label="$t('component.title.volumeNumber')"
+                    />
+                  </v-col>
+                </v-row>
+                <v-row
+                  v-if="isBook"
+                  dense
+                >
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.firstAuthor"
+                      :disabled="isReadonly"
+                      dense
+                      :label="$t('component.title.firstAuthor.label')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.firstEditor"
+                      :disabled="isReadonly"
+                      dense
+                      :label="$t('component.title.firstEditor.label')"
+                    />
+                  </v-col>
+                  <v-col>
+                    <gokb-text-field
+                      v-model="packageTitleItem.editionStatement"
+                      :disabled="isReadonly"
+                      dense
+                      :label="$t('component.title.editionStatement')"
+                    />
+                  </v-col>
+                </v-row>
+              </gokb-section>
+            </v-tab-item>
+            <v-tab-item key="prices">
+              <gokb-prices-section
+                v-model="packageTitleItem.prices"
+                :disabled="isReadonly"
+                no-tool-bar
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+          </v-tabs-items>
+        </v-col>
+      </v-row>
+      <template #buttons>
+        <gokb-button
+          v-if="!isReadonly"
+          @click="reset"
         >
-          <v-icon
-            :title="$t('component.general.dateCreated')"
-            class="pb-1"
-            medium
-          >
-            mdi-file-plus-outline
-          </v-icon>
-          <span class="ml-1">{{ localDateCreated }}</span>
-        </v-chip>
-        <v-chip
-          class="ma-1"
-          label
-        >
-          <v-icon
-            :title="$t('component.general.lastUpdated')"
-            class="pb-1"
+          {{ $t('btn.reset') }}
+        </gokb-button>
+        <v-spacer />
+        <div v-if="id && !notFound">
+          <v-chip
+            class="ma-1"
             label
-            medium
           >
-            mdi-refresh
-          </v-icon>
-          <span class="ml-1">{{ localLastUpdated }}</span>
-        </v-chip>
-      </div>
-      <v-spacer />
-      <gokb-button
-        v-if="updateUrl || !id"
-        :disabled="!packageTitleItem.title"
-        class="mr-6"
-        default
-      >
-        {{ $t('btn.update') }}
-      </gokb-button>
-    </template>
-  </gokb-page>
-  <gokb-page
-    v-else
-    title=""
-  >
-    <v-card>
-      <v-card-text>
-        <div class="text-h5 primary--text">
-          {{ $t('component.general.notFound', [$tc('component.tipp.label')]) }}
+            <v-icon
+              :title="$t('component.general.dateCreated')"
+              class="pb-1"
+              medium
+            >
+              mdi-file-plus-outline
+            </v-icon>
+            <span class="ml-1">{{ localDateCreated }}</span>
+          </v-chip>
+          <v-chip
+            class="ma-1"
+            label
+          >
+            <v-icon
+              :title="$t('component.general.lastUpdated')"
+              class="pb-1"
+              label
+              medium
+            >
+              mdi-refresh
+            </v-icon>
+            <span class="ml-1">{{ localLastUpdated }}</span>
+          </v-chip>
         </div>
-      </v-card-text>
-    </v-card>
-  </gokb-page>
+        <v-spacer />
+        <gokb-button
+          v-if="updateUrl || !id"
+          :disabled="!packageTitleItem.title"
+          class="mr-6"
+          default
+        >
+          {{ $t('btn.update') }}
+        </gokb-button>
+      </template>
+    </gokb-page>
+    <gokb-page
+      v-else
+      title=""
+    >
+      <v-card>
+        <v-card-text>
+          <div class="text-h5 primary--text">
+            {{ $t('component.general.notFound', [$tc('component.tipp.label')]) }}
+          </div>
+        </v-card-text>
+      </v-card>
+    </gokb-page>
+  </div>
 </template>
 
 <script>

--- a/src/views/edit/edit-title-view.vue
+++ b/src/views/edit/edit-title-view.vue
@@ -1,449 +1,451 @@
 <template>
-  <gokb-page
-    v-if="accessible && !notFound"
-    :key="version"
-    :title="title"
-    @submit="update"
-  >
-    <gokb-error-component :value="error" />
+  <div>
     <v-snackbars :objects.sync="eventMessages">
       <template #action="{ close }">
         <v-btn icon @click="close()"><v-icon>mdi-close</v-icon></v-btn>
       </template>
     </v-snackbars>
-    <v-row>
-      <v-col>
-        <gokb-select-field
-          v-if="!isEdit"
-          v-model="currentType"
-          :readonly="isReadonly"
-          :label="$t('component.title.type.label')"
-          class="ml-4"
-          :items="allTypes"
-          required
-        />
-      </v-col>
-      <v-spacer />
-    </v-row>
-    <gokb-section :no-tool-bar="true">
-      <v-row>
-        <v-col col="7">
-          <gokb-name-field
-            v-model="allNames"
-            :label="$t('component.general.name')"
-            :disabled="isReadonly"
-            :api-errors="errors.name"
-          />
-        </v-col>
-      </v-row>
-      <v-row v-if="id">
-        <v-col cols="6">
-          <gokb-state-select-field
-            v-model="titleItem.status"
-            :deletable="!isReadonly"
-            :editable="!isReadonly"
-            :api-errors="errors.status"
-            @delete="markDeleted"
-          />
-        </v-col>
-        <v-col cols="6" xl="3">
-          <gokb-uuid-field
-            v-if="id"
-            :label="$t('component.general.uuid.label')"
-            :value="titleItem.uuid"
-            path="/title"
-            dense
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col cols="3">
-          <gokb-state-field
-            v-model="titleItem.OAStatus"
-            message-path="component.title.OAStatus"
-            width="100%"
-            url="refdata/categories/TitleInstance.OAStatus"
-            :label="$t('component.title.OAStatus.label')"
-            :readonly="isReadonly"
-            :api-errors="errors.OAStatus"
-            dense
-          />
-        </v-col>
-        <v-col cols="3">
-          <gokb-state-field
-            v-model="titleItem.medium"
-            message-path="component.title.medium"
-            width="100%"
-            url="refdata/categories/TitleInstance.Medium"
-            :label="$t('component.title.medium.label')"
-            :readonly="isReadonly"
-            :api-errors="errors.medium"
-            dense
-          />
-        </v-col>
-        <v-col v-if="currentType == 'Book'">
-          <gokb-text-field
-            v-model="titleItem.firstAuthor"
-            :label="$t('component.title.firstAuthor.label')"
-            :disabled="isReadonly"
-            :api-errors="errors.firstAuthor"
-            dense
-          />
-        </v-col>
-        <v-col v-if="currentType == 'Book'">
-          <gokb-text-field
-            v-model="titleItem.firstEditor"
-            :label="$t('component.title.firstEditor.label')"
-            :disabled="isReadonly"
-            :api-errors="errors.firstEditor"
-            dense
-          />
-        </v-col>
-        <v-col v-if="currentType == 'Journal'">
-          <gokb-date-field
-            v-model="titleItem.publishedFrom"
-            :readonly="isReadonly"
-            :label="$t('component.title.publishedFrom')"
-            :api-errors="errors.publishedFrom"
-            dense
-          />
-        </v-col>
-        <v-col v-if="currentType == 'Journal'">
-          <gokb-date-field
-            v-model="titleItem.publishedTo"
-            :readonly="isReadonly"
-            :label="$t('component.title.publishedTo')"
-            :api-errors="errors.publishedTo"
-            dense
-          />
-        </v-col>
-      </v-row>
-      <v-row v-if="currentType == 'Book'">
-        <v-col cols="3">
-          <gokb-number-field
-            v-model="titleItem.volumeNumber"
-            :disabled="isReadonly"
-            :label="$t('component.title.volumeNumber')"
-            :api-errors="errors.volumeNumber"
-            dense
-          />
-        </v-col>
-        <v-col>
-          <gokb-text-field
-            v-model="titleItem.editionStatement"
-            :label="$t('component.title.editionStatement')"
-            :disabled="isReadonly"
-            :api-errors="errors.editionStatement"
-            dense
-          />
-        </v-col>
-        <v-col>
-          <gokb-date-field
-            v-model="titleItem.firstPublishedInPrint"
-            :readonly="isReadonly"
-            :label="$t('component.title.firstPublishedInPrint')"
-            :api-errors="errors.firstPublishedInPrint"
-            dense
-          />
-        </v-col>
-        <v-col>
-          <gokb-date-field
-            v-model="titleItem.firstPublishedOnline"
-            :readonly="isReadonly"
-            :label="$t('component.title.firstPublishedOnline')"
-            :api-errors="errors.firstPublishedOnline"
-            dense
-          />
-        </v-col>
-      </v-row>
-    </gokb-section>
-    <v-row
-      v-if="tabsView"
-      style="min-height:350px"
+    <gokb-page
+      v-if="accessible && !notFound"
+      :key="version"
+      :title="title"
+      @submit="update"
     >
-      <v-col>
-        <v-tabs
-          v-model="tab"
-          class="mx-4"
-        >
-          <v-tabs-slider color="black" />
+      <gokb-error-component :value="error" />
+      <v-row>
+        <v-col>
+          <gokb-select-field
+            v-if="!isEdit"
+            v-model="currentType"
+            :readonly="isReadonly"
+            :label="$t('component.title.type.label')"
+            class="ml-4"
+            :items="allTypes"
+            required
+          />
+        </v-col>
+        <v-spacer />
+      </v-row>
+      <gokb-section :no-tool-bar="true">
+        <v-row>
+          <v-col col="7">
+            <gokb-name-field
+              v-model="allNames"
+              :label="$t('component.general.name')"
+              :disabled="isReadonly"
+              :api-errors="errors.name"
+            />
+          </v-col>
+        </v-row>
+        <v-row v-if="id">
+          <v-col cols="6">
+            <gokb-state-select-field
+              v-model="titleItem.status"
+              :deletable="!isReadonly"
+              :editable="!isReadonly"
+              :api-errors="errors.status"
+              @delete="markDeleted"
+            />
+          </v-col>
+          <v-col cols="6" xl="3">
+            <gokb-uuid-field
+              v-if="id"
+              :label="$t('component.general.uuid.label')"
+              :value="titleItem.uuid"
+              path="/title"
+              dense
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="3">
+            <gokb-state-field
+              v-model="titleItem.OAStatus"
+              message-path="component.title.OAStatus"
+              width="100%"
+              url="refdata/categories/TitleInstance.OAStatus"
+              :label="$t('component.title.OAStatus.label')"
+              :readonly="isReadonly"
+              :api-errors="errors.OAStatus"
+              dense
+            />
+          </v-col>
+          <v-col cols="3">
+            <gokb-state-field
+              v-model="titleItem.medium"
+              message-path="component.title.medium"
+              width="100%"
+              url="refdata/categories/TitleInstance.Medium"
+              :label="$t('component.title.medium.label')"
+              :readonly="isReadonly"
+              :api-errors="errors.medium"
+              dense
+            />
+          </v-col>
+          <v-col v-if="currentType == 'Book'">
+            <gokb-text-field
+              v-model="titleItem.firstAuthor"
+              :label="$t('component.title.firstAuthor.label')"
+              :disabled="isReadonly"
+              :api-errors="errors.firstAuthor"
+              dense
+            />
+          </v-col>
+          <v-col v-if="currentType == 'Book'">
+            <gokb-text-field
+              v-model="titleItem.firstEditor"
+              :label="$t('component.title.firstEditor.label')"
+              :disabled="isReadonly"
+              :api-errors="errors.firstEditor"
+              dense
+            />
+          </v-col>
+          <v-col v-if="currentType == 'Journal'">
+            <gokb-date-field
+              v-model="titleItem.publishedFrom"
+              :readonly="isReadonly"
+              :label="$t('component.title.publishedFrom')"
+              :api-errors="errors.publishedFrom"
+              dense
+            />
+          </v-col>
+          <v-col v-if="currentType == 'Journal'">
+            <gokb-date-field
+              v-model="titleItem.publishedTo"
+              :readonly="isReadonly"
+              :label="$t('component.title.publishedTo')"
+              :api-errors="errors.publishedTo"
+              dense
+            />
+          </v-col>
+        </v-row>
+        <v-row v-if="currentType == 'Book'">
+          <v-col cols="3">
+            <gokb-number-field
+              v-model="titleItem.volumeNumber"
+              :disabled="isReadonly"
+              :label="$t('component.title.volumeNumber')"
+              :api-errors="errors.volumeNumber"
+              dense
+            />
+          </v-col>
+          <v-col>
+            <gokb-text-field
+              v-model="titleItem.editionStatement"
+              :label="$t('component.title.editionStatement')"
+              :disabled="isReadonly"
+              :api-errors="errors.editionStatement"
+              dense
+            />
+          </v-col>
+          <v-col>
+            <gokb-date-field
+              v-model="titleItem.firstPublishedInPrint"
+              :readonly="isReadonly"
+              :label="$t('component.title.firstPublishedInPrint')"
+              :api-errors="errors.firstPublishedInPrint"
+              dense
+            />
+          </v-col>
+          <v-col>
+            <gokb-date-field
+              v-model="titleItem.firstPublishedOnline"
+              :readonly="isReadonly"
+              :label="$t('component.title.firstPublishedOnline')"
+              :api-errors="errors.firstPublishedOnline"
+              dense
+            />
+          </v-col>
+        </v-row>
+      </gokb-section>
+      <v-row
+        v-if="tabsView"
+        style="min-height:350px"
+      >
+        <v-col>
+          <v-tabs
+            v-model="tab"
+            class="mx-4"
+          >
+            <v-tabs-slider color="black" />
 
-          <v-tab
-            key="identifiers"
-            :style="[!!errors.ids ? { border: '1px solid red', borderRadius: '2px' } : {}]"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.identifier.label', 2) }}
-            <v-chip class="ma-2">
-              {{ ids.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.ids"
-              :title="$t('pending.lists.changed')"
-              small
+            <v-tab
+              key="identifiers"
+              :style="[!!errors.ids ? { border: '1px solid red', borderRadius: '2px' } : {}]"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            key="publisher"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.title.publisher.label', 2) }}
-            <v-chip class="ma-2">
-              {{ publishers.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.publisher"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.identifier.label', 2) }}
+              <v-chip class="ma-2">
+                {{ ids.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.ids"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              key="publisher"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            key="variants"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.variantName.label', 2) }}
-            <v-chip class="ma-2">
-              {{ allNames.alts.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.variants"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.title.publisher.label', 2) }}
+              <v-chip class="ma-2">
+                {{ publishers.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.publisher"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              key="variants"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            v-if="id && isContrib"
-            key="reviews"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.review.label', 2) }}
-            <v-chip class="ma-2">
-              {{ reviewsCount }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.reviews"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.variantName.label', 2) }}
+              <v-chip class="ma-2">
+                {{ allNames.alts.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.variants"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              v-if="id && isContrib"
+              key="reviews"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-          <v-tab
-            v-if="id"
-            key="tipps"
-            :active-class="tabClass"
-          >
-            {{ $tc('component.tipp.label', 2) }}
-            <v-chip class="ma-2">
-              {{ tippCount }}
-            </v-chip>
-          </v-tab>
-          <v-tab
-            v-if="isEdit && history"
-            key="history"
-            :active-class="tabClass"
-          >
-            {{ $t('component.title.history.label') }}
-            <v-chip class="ma-2">
-              {{ history.length }}
-            </v-chip>
-            <v-icon
-              v-if="pendingChanges.history"
-              :title="$t('pending.lists.changed')"
-              small
+              {{ $tc('component.review.label', 2) }}
+              <v-chip class="ma-2">
+                {{ reviewsCount }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.reviews"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+            <v-tab
+              v-if="id"
+              key="tipps"
+              :active-class="tabClass"
             >
-              mdi-alert-decagram
-            </v-icon>
-          </v-tab>
-        </v-tabs>
-        <v-tabs-items
-          v-model="tab"
-        >
-          <v-tab-item
-            key="identifiers"
-            class="mt-4"
+              {{ $tc('component.tipp.label', 2) }}
+              <v-chip class="ma-2">
+                {{ tippCount }}
+              </v-chip>
+            </v-tab>
+            <v-tab
+              v-if="isEdit && history"
+              key="history"
+              :active-class="tabClass"
+            >
+              {{ $t('component.title.history.label') }}
+              <v-chip class="ma-2">
+                {{ history.length }}
+              </v-chip>
+              <v-icon
+                v-if="pendingChanges.history"
+                :title="$t('pending.lists.changed')"
+                small
+              >
+                mdi-alert-decagram
+              </v-icon>
+            </v-tab>
+          </v-tabs>
+          <v-tabs-items
+            v-model="tab"
           >
-            <gokb-identifier-section
-              v-model="ids"
-              :show-title="false"
-              :target-type="currentType"
-              :disabled="isReadonly || !currentType"
-              :api-errors="errors.ids"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="publishers"
-            class="mt-4"
-          >
-            <gokb-publisher-section
-              v-model="publishers"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.publisher"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="variants"
-            class="mt-4"
-          >
-            <gokb-alternate-names-section
-              v-model="allNames.alts"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.variantNames"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-          <v-tab-item
-            v-if="loggedIn && isContrib"
-            key="reviews"
-            class="mt-4"
-          >
-            <gokb-reviews-section
-              :review-component="titleItem"
-              :show-title="false"
-              :api-errors="errors.reviewRequests"
-              :expandable="false"
-              @update="refreshReviewsCount"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="tipps"
-            class="mt-4"
-          >
-            <gokb-tipps-section
-              :ttl="id"
-              :show-title="false"
-              :disabled="true"
-              :api-errors="errors.tipps"
-              @update="updateTippCount"
-            />
-          </v-tab-item>
-          <v-tab-item
-            key="history"
-            class="mt-4"
-          >
-            <gokb-title-history-section
-              v-model="history"
-              :title-info="shortTitleMap"
-              :show-title="false"
-              :disabled="isReadonly"
-              :api-errors="errors.history"
-              @update="addPendingChange"
-            />
-          </v-tab-item>
-        </v-tabs-items>
-      </v-col>
-    </v-row>
-    <div v-else>
-      <gokb-identifier-section
-        v-model="ids"
-        :disabled="isReadonly"
-        :target-type="currentType"
-        :api-errors="errors.ids"
-      />
-      <gokb-publisher-section
-        v-model="publishers"
-        :disabled="isReadonly"
-        :api-errors="errors.publisher"
-      />
-      <gokb-alternate-names-section
-        v-model="allNames.alts"
-        :disabled="isReadonly"
-        :api-errors="errors.variantNames"
-      />
-      <gokb-reviews-section
-        v-if="id && loggedIn"
-        :review-component="titleItem"
-        :api-errors="errors.reviewRequests"
-      />
-      <gokb-tipps-section
-        v-if="id"
-        :ttl="id"
-        :disabled="true"
-        :api-errors="errors.tipps"
-      />
-      <gokb-title-history-section
-        v-if="currentType === 'Journal'"
-        v-model="history"
-        :title-info="shortTitleMap"
-        :disabled="isReadonly"
-        :api-errors="errors.history"
-      />
-    </div>
-    <template #buttons>
-      <gokb-button
-        v-if="!isReadonly"
-        @click="reset"
-      >
-        {{ $i18n.t('btn.reset') }}
-      </gokb-button>
-      <v-spacer />
-      <div v-if="id">
-        <v-chip
-          class="ma-1"
-          label
-        >
-          <v-icon
-            :title="$t('component.general.dateCreated')"
-            class="pb-1"
-            medium
-          >
-            mdi-file-plus-outline
-          </v-icon>
-          <span class="ml-1">{{ localDateCreated }}</span>
-        </v-chip>
-        <v-chip
-          class="ma-1"
-          label
-        >
-          <v-icon
-            :title="$t('component.general.lastUpdated')"
-            class="pb-1"
-            label
-            medium
-          >
-            mdi-refresh
-          </v-icon>
-          <span class="ml-1">{{ localLastUpdated }}</span>
-        </v-chip>
+            <v-tab-item
+              key="identifiers"
+              class="mt-4"
+            >
+              <gokb-identifier-section
+                v-model="ids"
+                :show-title="false"
+                :target-type="currentType"
+                :disabled="isReadonly || !currentType"
+                :api-errors="errors.ids"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="publishers"
+              class="mt-4"
+            >
+              <gokb-publisher-section
+                v-model="publishers"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.publisher"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="variants"
+              class="mt-4"
+            >
+              <gokb-alternate-names-section
+                v-model="allNames.alts"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.variantNames"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+            <v-tab-item
+              v-if="loggedIn && isContrib"
+              key="reviews"
+              class="mt-4"
+            >
+              <gokb-reviews-section
+                :review-component="titleItem"
+                :show-title="false"
+                :api-errors="errors.reviewRequests"
+                :expandable="false"
+                @update="refreshReviewsCount"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="tipps"
+              class="mt-4"
+            >
+              <gokb-tipps-section
+                :ttl="id"
+                :show-title="false"
+                :disabled="true"
+                :api-errors="errors.tipps"
+                @update="updateTippCount"
+              />
+            </v-tab-item>
+            <v-tab-item
+              key="history"
+              class="mt-4"
+            >
+              <gokb-title-history-section
+                v-model="history"
+                :title-info="shortTitleMap"
+                :show-title="false"
+                :disabled="isReadonly"
+                :api-errors="errors.history"
+                @update="addPendingChange"
+              />
+            </v-tab-item>
+          </v-tabs-items>
+        </v-col>
+      </v-row>
+      <div v-else>
+        <gokb-identifier-section
+          v-model="ids"
+          :disabled="isReadonly"
+          :target-type="currentType"
+          :api-errors="errors.ids"
+        />
+        <gokb-publisher-section
+          v-model="publishers"
+          :disabled="isReadonly"
+          :api-errors="errors.publisher"
+        />
+        <gokb-alternate-names-section
+          v-model="allNames.alts"
+          :disabled="isReadonly"
+          :api-errors="errors.variantNames"
+        />
+        <gokb-reviews-section
+          v-if="id && loggedIn"
+          :review-component="titleItem"
+          :api-errors="errors.reviewRequests"
+        />
+        <gokb-tipps-section
+          v-if="id"
+          :ttl="id"
+          :disabled="true"
+          :api-errors="errors.tipps"
+        />
+        <gokb-title-history-section
+          v-if="currentType === 'Journal'"
+          v-model="history"
+          :title-info="shortTitleMap"
+          :disabled="isReadonly"
+          :api-errors="errors.history"
+        />
       </div>
-      <v-spacer />
-      <v-switch
-        v-model="tabsView"
-        class="pt-4 pr-6"
-        :label="$t('component.title.tabsView')"
-      />
-      <gokb-button
-        v-if="!isReadonly"
-        default
-        :disabled="!isValid"
-      >
-        {{ $i18n.t('btn.submit') }}
-      </gokb-button>
-    </template>
-  </gokb-page>
-  <gokb-no-access-field v-else-if="!accessible" />
-  <gokb-page
-    v-else
-    title=""
-  >
-    <v-card>
-      <v-card-text>
-        <div class="text-h5 primary--text">
-          {{ $t('component.general.notFound', [$tc('component.title.label')]) }}
+      <template #buttons>
+        <gokb-button
+          v-if="!isReadonly"
+          @click="reset"
+        >
+          {{ $i18n.t('btn.reset') }}
+        </gokb-button>
+        <v-spacer />
+        <div v-if="id">
+          <v-chip
+            class="ma-1"
+            label
+          >
+            <v-icon
+              :title="$t('component.general.dateCreated')"
+              class="pb-1"
+              medium
+            >
+              mdi-file-plus-outline
+            </v-icon>
+            <span class="ml-1">{{ localDateCreated }}</span>
+          </v-chip>
+          <v-chip
+            class="ma-1"
+            label
+          >
+            <v-icon
+              :title="$t('component.general.lastUpdated')"
+              class="pb-1"
+              label
+              medium
+            >
+              mdi-refresh
+            </v-icon>
+            <span class="ml-1">{{ localLastUpdated }}</span>
+          </v-chip>
         </div>
-      </v-card-text>
-    </v-card>
-  </gokb-page>
+        <v-spacer />
+        <v-switch
+          v-model="tabsView"
+          class="pt-4 pr-6"
+          :label="$t('component.title.tabsView')"
+        />
+        <gokb-button
+          v-if="!isReadonly"
+          default
+          :disabled="!isValid"
+        >
+          {{ $i18n.t('btn.submit') }}
+        </gokb-button>
+      </template>
+    </gokb-page>
+    <gokb-no-access-field v-else-if="!accessible" />
+    <gokb-page
+      v-else
+      title=""
+    >
+      <v-card>
+        <v-card-text>
+          <div class="text-h5 primary--text">
+            {{ $t('component.general.notFound', [$tc('component.title.label')]) }}
+          </div>
+        </v-card-text>
+      </v-card>
+    </gokb-page>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Moving snackbars component out of gokb-page component avoids API calls removing active snackbars.